### PR TITLE
Fix setup.py to include api and imp subpackages and requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     download_url = github_url + '/tarball/v' + version,
     packages=['chartmogul', 'chartmogul.api', 'chartmogul.imp'],
     package_data={'': ['LICENSE', 'NOTICE'], 'chartmogul': ['*.pem']},
-    package_dir={'chartmogul': 'chartmogul'},
+    package_dir={'chartmogul': 'chartmogul', 'chartmogul.api': 'chartmogul/api', 'chartmogul.imp': 'chartmogul/imp'},
     include_package_data=True,
     install_requires=requires,
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,13 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
-requires = []
+requires = [
+    'requests>=2.10.0',
+    'uritemplate==3.0.0',
+    'promise==1.0.1',
+    'marshmallow==2.12.2',
+    'future==0.16.0',
+]
 test_requirements = ['mock>=1.0.1', 'requests-mock>=1.3.0']
 
 with open('chartmogul/__init__.py', 'r') as fd:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='petr@chartmogul.com',
     url='https://chartmogul.com',
     download_url = github_url + '/tarball/v' + version,
-    packages=['chartmogul'],
+    packages=['chartmogul', 'chartmogul.api', 'chartmogul.imp'],
     package_data={'': ['LICENSE', 'NOTICE'], 'chartmogul': ['*.pem']},
     package_dir={'chartmogul': 'chartmogul'},
     include_package_data=True,


### PR DESCRIPTION
The api and imp subpackages need to be explicitly included in the setup.py script or else they will not be installed.  The current version in pip (1.0.1) and the current commit on master both produce the same `ImportError: No module named api.config` exception for us because the api sub-package is not included.

This also adds the required packages to the setup script so that they are automatically installed via pip.  I did not make an effort to find the lowest compatible version of each requirement, but that should probably be done to ensure this package is compatible with other packages without having conflicting requirements.