### PR TITLE
Deprecation notice on imp, Subscription now one class

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ chartmogul.Plan.destroy(config, uuid='')
 ```python
 import chartmogul.imp
 
-chartmogul.imp.Invoice.create(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb', data={})
-chartmogul.imp.Invoice.all(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb', page=2, per_page=10)
+chartmogul.Invoice.create(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb', data={})
+chartmogul.Invoice.all(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb', page=2, per_page=10)
 ```
 
 #### [Transactions](https://dev.chartmogul.com/docs/transactions)
@@ -194,7 +194,7 @@ chartmogul.imp.Invoice.all(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4c
 ```python
 import chartmogul.imp
 
-chartmogul.imp.Transaction.create(config, uuid='inv_745df1d4-819f-48ee-873d-b5204801e021', data={})
+chartmogul.Transaction.create(config, uuid='inv_745df1d4-819f-48ee-873d-b5204801e021', data={})
 ```
 
 #### [Subscriptions](https://dev.chartmogul.com/docs/subscriptions)
@@ -202,9 +202,9 @@ chartmogul.imp.Transaction.create(config, uuid='inv_745df1d4-819f-48ee-873d-b520
 ```python
 import chartmogul.imp
 
-chartmogul.imp.Subscription.all(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb')
-chartmogul.imp.Subscription.cancel(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb' data={'cancelled_at': ''})
-chartmogul.imp.Subscription.modify(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb' data={'cancellation_dates': []})
+chartmogul.Subscription.list_imported(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb')
+chartmogul.Subscription.cancel(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb' data={'cancelled_at': ''})
+chartmogul.Subscription.modify(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb' data={'cancellation_dates': []})
 ```
 
 ### [Metrics API](https://dev.chartmogul.com/docs/introduction-metrics-api)

--- a/chartmogul/__init__.py
+++ b/chartmogul/__init__.py
@@ -2,18 +2,20 @@
 from .api.config import Config
 from .errors import APIError, ConfigurationError, ArgumentMissingError
 
-from .api.ping import Ping
-from .api.data_source import DataSource
-from .api.plan import Plan
-from .api.customer import Customer
-from .api.attributes import Attributes
-from .api.tags import Tags
 from .api.activity import Activity
-from .api.subscription import Subscription
-from .api.metrics import Metrics
+from .api.attributes import Attributes
 from .api.custom_attrs import CustomAttributes
+from .api.customer import Customer
+from .api.data_source import DataSource
+from .api.invoice import Invoice
+from .api.metrics import Metrics
+from .api.ping import Ping
+from .api.plan import Plan
+from .api.subscription import Subscription
+from .api.tags import Tags
+from .api.transaction import Transaction
 
-# Can't merge modules, because of Subscription clash.
+# Deprecated
 import imp
 
 
@@ -27,7 +29,7 @@ Provides convenient Python bindings for ChartMogul's API.
 """
 
 __title__ = 'chartmogul'
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 __build__ = 0x000000
 __author__ = 'ChartMogul Ltd'
 __license__ = 'MIT'

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -1,0 +1,53 @@
+from marshmallow import Schema, fields, post_load
+from ..resource import Resource, DataObject
+from .transaction import Transaction
+from collections import namedtuple
+
+
+class LineItem(DataObject):
+
+    class _Schema(Schema):
+        uuid = fields.String()
+        external_id = fields.String(allow_none=True)
+        type = fields.String()
+        subscription_uuid = fields.String()
+        subscription_external_id = fields.String()
+        plan_uuid = fields.String()
+        prorated = fields.Boolean()
+        service_period_start = fields.DateTime()
+        service_period_end = fields.DateTime()
+        amount_in_cents = fields.Int()
+        quantity = fields.Int()
+        discount_code = fields.String(allow_none=True)
+        discount_amount_in_cents = fields.Int()
+        tax_amount_in_cents = fields.Int()
+        account_code = fields.String(allow_none=True)
+
+        @post_load
+        def make(self, data):
+            return LineItem(**data)
+
+
+class Invoice(Resource):
+    """
+    https://dev.chartmogul.com/v1.0/reference#invoices
+    """
+    _path = "/import/customers{/uuid}/invoices"
+    _root_key = 'invoices'
+    _many = namedtuple('Invoices', [_root_key, "current_page", "total_pages", "customer_uuid"])
+    _many.__new__.__defaults__ = (None,) * len(_many._fields)
+
+    class _Schema(Schema):
+        uuid = fields.String()
+        external_id = fields.String(allow_none=True)
+        date = fields.DateTime()
+        due_date = fields.DateTime()
+        currency = fields.String()
+        line_items = fields.Nested(LineItem._Schema, many=True)
+        transactions = fields.Nested(Transaction._Schema, many=True)
+
+        @post_load
+        def make(self, data):
+            return Invoice(**data)
+
+    _schema = _Schema(strict=True)

--- a/chartmogul/api/subscription.py
+++ b/chartmogul/api/subscription.py
@@ -6,27 +6,52 @@ from collections import namedtuple
 class Subscription(Resource):
     """
     https://dev.chartmogul.com/v1.0/reference#list-customer-subscriptions
+    https://dev.chartmogul.com/v1.0/reference#list-a-customers-subscriptions
     """
     _path = "/customers{/uuid}/subscriptions"
     _root_key = 'entries'
     _many = namedtuple('Subscriptions', [_root_key, "has_more", "per_page", "page"])
 
     class _Schema(Schema):
-        id = fields.Int()
-        plan = fields.String()
-        quantity = fields.Int()
-        mrr = fields.Number()
-        arr = fields.Number()
-        status = fields.String()
-        billing_cycle = fields.String(load_from='billing-cycle')
-        billing_cycle_count = fields.Number(load_from='billing-cycle-count')
-        start_date = fields.DateTime(load_from='start-date')
-        end_date = fields.DateTime(load_from='end-date')
-        currency = fields.String()
-        currency_sign = fields.String(load_from='currency-sign')
+        id = fields.Int(allow_none=True)
+        plan = fields.String(allow_none=True)
+        quantity = fields.Int(allow_none=True)
+        mrr = fields.Number(allow_none=True)
+        arr = fields.Number(allow_none=True)
+        status = fields.String(allow_none=True)
+        billing_cycle = fields.String(load_from='billing-cycle', allow_none=True)
+        billing_cycle_count = fields.Number(load_from='billing-cycle-count', allow_none=True)
+        start_date = fields.DateTime(load_from='start-date', allow_none=True)
+        end_date = fields.DateTime(load_from='end-date', allow_none=True)
+        currency = fields.String(allow_none=True)
+        currency_sign = fields.String(load_from='currency-sign', allow_none=True)
+
+        # /import namespace
+        uuid = fields.String(allow_none=True)
+        external_id = fields.String(allow_none=True)
+        plan_uuid = fields.String(allow_none=True)
+        customer_uuid = fields.String(allow_none=True)
+        data_source_uuid = fields.String(allow_none=True)
+        cancellation_dates = fields.List(fields.DateTime(), allow_none=True)
 
         @post_load
         def make(self, data):
             return Subscription(**data)
 
     _schema = _Schema(strict=True)
+
+    # /import has different paging
+    @classmethod
+    def _loadJSON(cls, jsonObj):
+        if "subscriptions" in jsonObj:
+            _many = namedtuple('Subscriptions', ["subscriptions", "current_page", "total_pages"])
+            return _many(cls._schema.load(jsonObj["subscriptions"], many=True).data,
+                         jsonObj["current_page"],
+                         jsonObj["total_pages"])
+        else:
+            return super(Subscription, cls)._loadJSON(jsonObj)
+
+# /import namespace
+Subscription.list_imported = Subscription._method('list_imported', 'get', "/import/customers{/uuid}/subscriptions")
+Subscription.cancel = Subscription._method('cancel', 'patch', "/import/subscriptions{/uuid}")
+Subscription.modify = Subscription._method('modify', 'patch', "/import/subscriptions{/uuid}")

--- a/chartmogul/api/transaction.py
+++ b/chartmogul/api/transaction.py
@@ -1,0 +1,23 @@
+from marshmallow import Schema, fields, post_load
+from ..resource import Resource
+from collections import namedtuple
+
+
+class Transaction(Resource):
+    """
+    https://dev.chartmogul.com/v1.0/reference#transactions
+    """
+    _path = "/import/invoices{/uuid}/transactions"
+
+    class _Schema(Schema):
+        uuid = fields.String()
+        external_id = fields.String(allow_none=True)
+        type = fields.String()
+        date = fields.DateTime()
+        result = fields.String()
+
+        @post_load
+        def make(self, data):
+            return Transaction(**data)
+
+    _schema = _Schema(strict=True)

--- a/chartmogul/imp/__init__.py
+++ b/chartmogul/imp/__init__.py
@@ -1,4 +1,4 @@
-# In future versions this might be merged into api
+# Deprecated
 from .invoice import Invoice
 from .transaction import Transaction
 from .subscription import Subscription

--- a/chartmogul/imp/invoice.py
+++ b/chartmogul/imp/invoice.py
@@ -1,52 +1,14 @@
-from marshmallow import Schema, fields, post_load
-from ..resource import Resource, DataObject
-from .transaction import Transaction
-from collections import namedtuple
+from ..api.invoice import Invoice as InvoiceNew
+from warnings import warn
 
 
-class LineItem(DataObject):
+class Invoice(InvoiceNew):
+    @classmethod
+    def create(cls, *args, **kwargs):
+        warn("chartmogul.imp namespace is deprecated, use chartmogul.Invoice.create!")
+        return super(Invoice, cls).create(*args, **kwargs)
 
-    class _Schema(Schema):
-        uuid = fields.String()
-        external_id = fields.String(allow_none=True)
-        type = fields.String()
-        subscription_uuid = fields.String()
-        plan_uuid = fields.String()
-        prorated = fields.Boolean()
-        service_period_start = fields.DateTime()
-        service_period_end = fields.DateTime()
-        amount_in_cents = fields.Int()
-        quantity = fields.Int()
-        discount_code = fields.String(allow_none=True)
-        discount_amount_in_cents = fields.Int()
-        tax_amount_in_cents = fields.Int()
-        account_code = fields.String(allow_none=True)
-
-        @post_load
-        def make(self, data):
-            return LineItem(**data)
-
-
-class Invoice(Resource):
-    """
-    https://dev.chartmogul.com/v1.0/reference#invoices
-    """
-    _path = "/import/customers{/uuid}/invoices"
-    _root_key = 'invoices'
-    _many = namedtuple('Invoices', [_root_key, "current_page", "total_pages", "customer_uuid"])
-    _many.__new__.__defaults__ = (None,) * len(_many._fields)
-
-    class _Schema(Schema):
-        uuid = fields.String()
-        external_id = fields.String(allow_none=True)
-        date = fields.DateTime()
-        due_date = fields.DateTime()
-        currency = fields.String()
-        line_items = fields.Nested(LineItem._Schema, many=True)
-        transactions = fields.Nested(Transaction._Schema, many=True)
-
-        @post_load
-        def make(self, data):
-            return Invoice(**data)
-
-    _schema = _Schema(strict=True)
+    @classmethod
+    def all(cls, *args, **kwargs):
+        warn("chartmogul.imp namespace is deprecated, use chartmogul.Invoice.all!")
+        return super(Invoice, cls).all(*args, **kwargs)

--- a/chartmogul/imp/subscription.py
+++ b/chartmogul/imp/subscription.py
@@ -1,30 +1,14 @@
-from marshmallow import Schema, fields, post_load
-from ..resource import Resource
-from collections import namedtuple
+from ..api.subscription import Subscription as SubsNew
+from warnings import warn
 
 
-class Subscription(Resource):
-    """
-    https://dev.chartmogul.com/v1.0/reference#subscriptions
-    """
-    _path = "/import/customers{/uuid}/subscriptions"
-    _root_key = 'subscriptions'
-    _many = namedtuple('Subscriptions', [_root_key, "current_page", "total_pages", "customer_uuid"])
+class Subscription(SubsNew):
+    @classmethod
+    def all(cls, *args, **kwargs):
+        warn("chartmogul.imp namespace is deprecated, use chartmogul.Subscription.list_imported!")
+        return super(Subscription, cls).list_imported(*args, **kwargs)
 
-    class _Schema(Schema):
-        uuid = fields.String()
-        external_id = fields.String()
-        plan_uuid = fields.String()
-        customer_uuid = fields.String()
-        data_source_uuid = fields.String()
-        cancellation_dates = fields.List(fields.DateTime())
-
-        @post_load
-        def make(self, data):
-            return Subscription(**data)
-
-    _schema = _Schema(strict=True)
-
-
-Subscription.cancel = Subscription._method('cancel', 'patch', "/import/subscriptions{/uuid}")
-Subscription.modify = Subscription._method('modify', 'patch', "/import/subscriptions{/uuid}")
+    @classmethod
+    def cancel(cls, *args, **kwargs):
+        warn("chartmogul.imp namespace is deprecated, use chartmogul.Subscription.cancel!")
+        return super(Subscription, cls).cancel(*args, **kwargs)

--- a/chartmogul/imp/transaction.py
+++ b/chartmogul/imp/transaction.py
@@ -1,23 +1,9 @@
-from marshmallow import Schema, fields, post_load
-from ..resource import Resource
-from collections import namedtuple
+from ..api.transaction import Transaction as TransactionNew
+from warnings import warn
 
 
-class Transaction(Resource):
-    """
-    https://dev.chartmogul.com/v1.0/reference#transactions
-    """
-    _path = "/import/invoices{/uuid}/transactions"
-
-    class _Schema(Schema):
-        uuid = fields.String()
-        external_id = fields.String(allow_none=True)
-        type = fields.String()
-        date = fields.DateTime()
-        result = fields.String()
-
-        @post_load
-        def make(self, data):
-            return Transaction(**data)
-
-    _schema = _Schema(strict=True)
+class Transaction(TransactionNew):
+    @classmethod
+    def create(cls, *args, **kwargs):
+        warn("chartmogul.imp namespace is deprecated, use chartmogul.Transaction.create!")
+        return super(Transaction, cls).create(*args, **kwargs)

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -89,7 +89,10 @@ class Resource(DataObject):
             jsonObj = response.json()
         except ValueError:  # Couldn't parse JSON, probably just text message.
             return response.content
+        return cls._loadJSON(jsonObj)
 
+    @classmethod
+    def _loadJSON(cls, jsonObj):
         # has load_many capability & is many entries result?
         if '_root_key' in dir(cls) is not None and cls._root_key in jsonObj:
             return cls._many(cls._schema.load(jsonObj[cls._root_key], many=True).data,
@@ -115,6 +118,7 @@ class Resource(DataObject):
             if data is not None:
                 data = dumps(data, default=json_serial)
 
+        print(method, http_verb, path)
         return Promise(lambda resolve, _:
                        resolve(getattr(requests, http_verb)(
                            config.uri + path,

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -33,7 +33,7 @@ ESCAPED_QUERY_KEYS = {
 }
 
 
-class DataObject:
+class DataObject(object):
 
     def __init__(self, **kwargs):
         """

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -118,7 +118,6 @@ class Resource(DataObject):
             if data is not None:
                 data = dumps(data, default=json_serial)
 
-        print(method, http_verb, path)
         return Promise(lambda resolve, _:
                        resolve(getattr(requests, http_verb)(
                            config.uri + path,

--- a/test/api/test_invoice.py
+++ b/test/api/test_invoice.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import requests_mock
 
 from chartmogul import Config
-from chartmogul.imp import Invoice
+from chartmogul import Invoice
 
 
 requestData = {

--- a/test/api/test_subscription.py
+++ b/test/api/test_subscription.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import requests_mock
 
 from chartmogul import Config
-from chartmogul.imp import Subscription
+from chartmogul import Subscription
 
 
 class SubscriptionsTestCase(unittest.TestCase):


### PR DESCRIPTION
* we're deprecating `chartmogul.imp`, classes moved to main namespace, backwards compatible
* version to 1.1.0
* will be unified with how other client libraries look now
* can cause problem if importing `from chartmogul import *` and `from chartmogul.imp import *`, then just delete the second one