### PR TITLE
added an optional timeout to all requests

### DIFF
--- a/chartmogul/api/config.py
+++ b/chartmogul/api/config.py
@@ -5,5 +5,6 @@ API_BASE = "https://api.chartmogul.com"
 class Config:
     uri = API_BASE + "/" + VERSION
 
-    def __init__(self, account_token, secret_key):
+    def __init__(self, account_token, secret_key, request_timeout=None):
         self.auth = (account_token, secret_key)
+        self.request_timeout = request_timeout

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -124,7 +124,8 @@ class Resource(DataObject):
                            data=data,
                            headers={'content-type': 'application/json'},
                            params=params,
-                           auth=config.auth)
+                           auth=config.auth,
+                           timeout=config.request_timeout)
                        )).then(cls._load).catch(annotateHTTPError)
 
     @classmethod


### PR DESCRIPTION
ChartMogul's API was down for a few minutes recently, and without a timeout this caused some trouble in our integration. The added argument is optional and the default does not change any current behavior.