### PR TITLE
Added method for Connect subscriptions [ch4617]

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ chartmogul.Customer.modify(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4c
   'into': {'customer_uuid': 'cus_2123290f-09c8-4628-a205-db5596bd58f7'}
 })
 chartmogul.Customer.destroy(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb')
+chartmogul.Customer.connectSubscriptions(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb', data={
+  'subscriptions': [
+    {
+      "data_source_uuid": "ds_ade45e52-47a4-231a-1ed2-eb6b9e541213",
+      "external_id": "d1c0c885-add0-48db-8fa9-0bdf5017d6b0"
+    },
+    {
+      "data_source_uuid": "ds_ade45e52-47a4-231a-1ed2-eb6b9e541213",
+      "external_id": "9db5f4a1-1695-44c0-8bd4-de7ce4d0f1d4"
+    }
+  ]
+})
 ```
 
 #### [Customer Attributes](https://dev.chartmogul.com/docs/customer-attributes)

--- a/chartmogul/api/customer.py
+++ b/chartmogul/api/customer.py
@@ -75,3 +75,4 @@ class Customer(Resource):
 
 Customer.search = Customer._method('all', 'get', '/customers/search')
 Customer.merge = Customer._method('merge', 'post', '/customers/merges')
+Customer.connectSubscriptions = Customer._method('create', 'post', '/customers/{uuid}/connect_subscriptions')

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -84,7 +84,7 @@ class Resource(DataObject):
         (immutable, therefore all set on creation by generator)
         """
         response.raise_for_status()
-        if response.status_code == 204:
+        if response.status_code == 204 or response.status_code == 202:
             return None
         try:
             jsonObj = response.json()

--- a/test/api/test_customer.py
+++ b/test/api/test_customer.py
@@ -375,3 +375,29 @@ class CustomerTestCase(unittest.TestCase):
         self.assertEqual(mock_requests.last_request.qs, {})
         self.assertEqual(mock_requests.last_request.json(), jsonRequest)
         self.assertEqual(result, None)
+    @requests_mock.mock()
+    def test_connectSubscriptions(self, mock_requests):
+        mock_requests.register_uri(
+            'POST',
+            "https://api.chartmogul.com/v1/customers/cus_5915ee5a-babd-406b-b8ce-d207133fb4cb/connect_subscriptions",
+            status_code=202
+        )
+
+        jsonRequest = {
+          'subscriptions': [
+            {
+              "data_source_uuid": "ds_ade45e52-47a4-231a-1ed2-eb6b9e541213",
+              "external_id": "d1c0c885-add0-48db-8fa9-0bdf5017d6b0"
+            },
+            {
+              "data_source_uuid": "ds_ade45e52-47a4-231a-1ed2-eb6b9e541213",
+              "external_id": "9db5f4a1-1695-44c0-8bd4-de7ce4d0f1d4"
+            }
+          ]
+        }
+        config = Config("token", "secret")
+        result = Customer.connectSubscriptions(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb', data=jsonRequest).get()
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(mock_requests.last_request.qs, {})
+        self.assertEqual(mock_requests.last_request.json(), jsonRequest)
+        self.assertEqual(result, None)


### PR DESCRIPTION
Added connectSubscription method: https://dev.chartmogul.com/reference#connect-subscriptions
Example:
```python
chartmogul.Customer.connectSubscriptions(config, uuid='cus_5915ee5a-babd-406b-b8ce-d207133fb4cb', data={
  'subscriptions': [
    {
      "data_source_uuid": "ds_ade45e52-47a4-231a-1ed2-eb6b9e541213",
      "external_id": "d1c0c885-add0-48db-8fa9-0bdf5017d6b0"
    },
    {
      "data_source_uuid": "ds_ade45e52-47a4-231a-1ed2-eb6b9e541213",
      "external_id": "9db5f4a1-1695-44c0-8bd4-de7ce4d0f1d4"
    }
  ]
})
```

