### PR TITLE
Update client get endpoints for MCS [chch16182]

### DIFF
--- a/chartmogul/__init__.py
+++ b/chartmogul/__init__.py
@@ -29,8 +29,8 @@ Provides convenient Python bindings for ChartMogul's API.
 """
 
 __title__ = 'chartmogul'
-__version__ = '1.2.4'
+__version__ = '1.2.5'
 __build__ = 0x000000
 __author__ = 'ChartMogul Ltd'
 __license__ = 'MIT'
-__copyright__ = 'Copyright 2017 ChartMogul Ltd'
+__copyright__ = 'Copyright 2019 ChartMogul Ltd'

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -12,6 +12,7 @@ class LineItem(DataObject):
         type = fields.String()
         subscription_uuid = fields.String(allow_none=True)
         subscription_external_id = fields.String(allow_none=True)
+        subscription_set_external_id = fields.String(allow_none=True)
         plan_uuid = fields.String(allow_none=True)
         prorated = fields.Boolean()
         service_period_start = fields.DateTime(allow_none=True)

--- a/chartmogul/api/subscription.py
+++ b/chartmogul/api/subscription.py
@@ -29,6 +29,7 @@ class Subscription(Resource):
         # /import namespace
         uuid = fields.String(allow_none=True)
         external_id = fields.String(allow_none=True)
+        subscription_set_external_id = fields.String(allow_none=True)
         plan_uuid = fields.String(allow_none=True)
         customer_uuid = fields.String(allow_none=True)
         data_source_uuid = fields.String(allow_none=True)

--- a/test/api/test_subscription.py
+++ b/test/api/test_subscription.py
@@ -95,6 +95,7 @@ class SubscriptionsTestCase(unittest.TestCase):
                     {
                       "uuid": "sub_e6bc5407-e258-4de0-bb43-61faaf062035",
                       "external_id": "sub_0001",
+                      "subscription_set_external_id": "sub_set_0001",
                       "plan_uuid": "pl_eed05d54-75b4-431b-adb2-eb6b9e543206",
                       "data_source_uuid": "ds_fef05d54-47b4-431b-aed2-eb6b9e545430",
                       "cancellation_dates":[]


### PR DESCRIPTION
We want to include the `subscription_set_external_id` in the responses for Subscription and Invoice.

The Import Invoice already works as expected (MCS) when attribute `subscription_set_external_id` is provided in the `data = {}`