### PR TITLE
Upgrade the Marshmallow dependency to be >=3.10.0 (#38)

### DIFF
--- a/chartmogul/__init__.py
+++ b/chartmogul/__init__.py
@@ -30,7 +30,7 @@ Provides convenient Python bindings for ChartMogul's API.
 """
 
 __title__ = 'chartmogul'
-__version__ = '1.4.1'
+__version__ = '1.5.0'
 __build__ = 0x000000
 __author__ = 'ChartMogul Ltd'
 __license__ = 'MIT'

--- a/chartmogul/api/activity.py
+++ b/chartmogul/api/activity.py
@@ -13,17 +13,17 @@ class Activity(Resource):
 
     class _Schema(Schema):
         id = fields.Int()
-        activity_arr = fields.Number(load_from='activity-arr')
-        activity_mrr = fields.Number(load_from='activity-mrr')
-        activity_mrr_movement = fields.Number(load_from='activity-mrr-movement')
+        activity_arr = fields.Number(data_key='activity-arr')
+        activity_mrr = fields.Number(data_key='activity-mrr')
+        activity_mrr_movement = fields.Number(data_key='activity-mrr-movement')
         currency = fields.String()
-        currency_sign = fields.String(load_from='currency-sign')
+        currency_sign = fields.String(data_key='currency-sign')
         date = fields.DateTime()
         description = fields.String()
         type = fields.String()
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Activity(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()

--- a/chartmogul/api/attributes.py
+++ b/chartmogul/api/attributes.py
@@ -14,7 +14,7 @@ class Attributes(Resource):
         custom = fields.Dict()
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Attributes(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()

--- a/chartmogul/api/custom_attrs.py
+++ b/chartmogul/api/custom_attrs.py
@@ -14,11 +14,11 @@ class CustomAttributes(Resource):
         custom = fields.Dict()
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return CustomAttributes(**data)
 
     _customers = namedtuple('Customers', ['entries'])
-    _schema = _Schema(strict=True)
+    _schema = _Schema()
 
     @classmethod
     def _load(cls, response):
@@ -31,7 +31,7 @@ class CustomAttributes(Resource):
             return None
         jsonObj = response.json()
         if 'entries' in jsonObj:
-            customers = Customer._schema.load(jsonObj['entries'], many=True).data
+            customers = Customer._schema.load(jsonObj['entries'], many=True)
             return cls._customers(customers)
         else:
-            return cls._schema.load(jsonObj).data
+            return cls._schema.load(jsonObj)

--- a/chartmogul/api/customer.py
+++ b/chartmogul/api/customer.py
@@ -20,7 +20,7 @@ class Address(DataObject):
         state = fields.String(allow_none=True)
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Address(**data)
 
 
@@ -56,21 +56,21 @@ class Customer(Resource):
         external_ids = fields.List(fields.String())
         data_source_uuids = fields.List(fields.String())
         status = fields.String()
-        customer_since = fields.DateTime(load_from="customer-since", allow_none=True)
+        customer_since = fields.DateTime(data_key="customer-since", allow_none=True)
         mrr = fields.Number()
         arr = fields.Number()
-        billing_system_url = fields.String(load_from="billing-system-url", allow_none=True)
-        chartmogul_url = fields.String(load_from="chartmogul-url")
-        billing_system_type = fields.String(load_from="billing-system-type")
+        billing_system_url = fields.String(data_key="billing-system-url", allow_none=True)
+        chartmogul_url = fields.String(data_key="chartmogul-url")
+        billing_system_type = fields.String(data_key="billing-system-type")
         currency = fields.String()
-        currency_sign = fields.String(load_from="currency-sign")
+        currency_sign = fields.String(data_key="currency-sign")
         address = fields.Nested(Address._Schema, allow_none=True)
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Customer(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()
 
 
 Customer.search = Customer._method('all', 'get', '/customers/search')

--- a/chartmogul/api/data_source.py
+++ b/chartmogul/api/data_source.py
@@ -19,7 +19,7 @@ class DataSource(Resource):
         system = fields.Str()
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return DataSource(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -24,9 +24,10 @@ class LineItem(DataObject):
         tax_amount_in_cents = fields.Int()
         transaction_fees_in_cents = fields.Int()
         account_code = fields.String(allow_none=True)
+        description = fields.String(allow_none=True)
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return LineItem(**data)
 
 
@@ -54,10 +55,10 @@ class Invoice(Resource):
         transactions = fields.Nested(Transaction._Schema, many=True)
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Invoice(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()
 
     @classmethod
     def all(cls, config, **kwargs):

--- a/chartmogul/api/metrics.py
+++ b/chartmogul/api/metrics.py
@@ -10,13 +10,13 @@ class Summary(DataObject):
     class _Schema(Schema):
         current = fields.Number()
         previous = fields.Number()
-        percentage_change = fields.Number(load_from='percentage-change')
+        percentage_change = fields.Number(data_key='percentage-change')
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Summary(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()
 
 
 class Metrics(Resource):
@@ -33,8 +33,8 @@ class Metrics(Resource):
         Fields are optional, so a subset present is good enough
         """
         date = fields.Date()
-        customer_churn_rate = fields.Number(load_from='customer-churn-rate')
-        mrr_churn_rate = fields.Number(load_from='mrr-churn-rate')
+        customer_churn_rate = fields.Number(data_key='customer-churn-rate')
+        mrr_churn_rate = fields.Number(data_key='mrr-churn-rate')
         ltv = fields.Number()
         customers = fields.Number()
         asp = fields.Number()
@@ -42,22 +42,22 @@ class Metrics(Resource):
         arr = fields.Number()
         mrr = fields.Number()
         # MRR only
-        mrr_new_business = fields.Number(load_from='mrr-new-business')
-        mrr_expansion = fields.Number(load_from='mrr-expansion')
-        mrr_contraction = fields.Number(load_from='mrr-contraction')
-        mrr_churn = fields.Number(load_from='mrr-churn')
-        mrr_reactivation = fields.Number(load_from='mrr-reactivation')
+        mrr_new_business = fields.Number(data_key='mrr-new-business')
+        mrr_expansion = fields.Number(data_key='mrr-expansion')
+        mrr_contraction = fields.Number(data_key='mrr-contraction')
+        mrr_churn = fields.Number(data_key='mrr-churn')
+        mrr_reactivation = fields.Number(data_key='mrr-reactivation')
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Metrics(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()
 
     @classmethod
     def _many(cls, entries, **kwargs):
         if 'summary' in kwargs:
-            kwargs['summary'] = Summary._schema.load(kwargs['summary']).data
+            kwargs['summary'] = Summary._schema.load(kwargs['summary'])
         return cls._many_cls(entries, **kwargs)
 
 

--- a/chartmogul/api/ping.py
+++ b/chartmogul/api/ping.py
@@ -13,10 +13,10 @@ class Ping(Resource):
         data = fields.String()
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Ping(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()
 
 
 _add_method(Ping, "ping", "get")

--- a/chartmogul/api/plan.py
+++ b/chartmogul/api/plan.py
@@ -20,7 +20,7 @@ class Plan(Resource):
         external_id = fields.String()
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Plan(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()

--- a/chartmogul/api/plan_group.py
+++ b/chartmogul/api/plan_group.py
@@ -18,10 +18,10 @@ class PlanGroup(Resource):
         plans_count = fields.Int()
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return PlanGroup(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()
 
     @classmethod
     def all(cls, config, **kwargs):

--- a/chartmogul/api/plan_group_plans.py
+++ b/chartmogul/api/plan_group_plans.py
@@ -20,7 +20,7 @@ class PlanGroupPlans(Resource):
         external_id = fields.String()
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return PlanGroupPlans(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()

--- a/chartmogul/api/subscription.py
+++ b/chartmogul/api/subscription.py
@@ -19,12 +19,12 @@ class Subscription(Resource):
         mrr = fields.Number(allow_none=True)
         arr = fields.Number(allow_none=True)
         status = fields.String(allow_none=True)
-        billing_cycle = fields.String(load_from='billing-cycle', allow_none=True)
-        billing_cycle_count = fields.Number(load_from='billing-cycle-count', allow_none=True)
-        start_date = fields.DateTime(load_from='start-date', allow_none=True)
-        end_date = fields.DateTime(load_from='end-date', allow_none=True)
+        billing_cycle = fields.String(data_key='billing-cycle', allow_none=True)
+        billing_cycle_count = fields.Number(data_key='billing-cycle-count', allow_none=True)
+        start_date = fields.DateTime(data_key='start-date', allow_none=True)
+        end_date = fields.DateTime(data_key='end-date', allow_none=True)
         currency = fields.String(allow_none=True)
-        currency_sign = fields.String(load_from='currency-sign', allow_none=True)
+        currency_sign = fields.String(data_key='currency-sign', allow_none=True)
 
         # /import namespace
         uuid = fields.String(allow_none=True)
@@ -36,17 +36,17 @@ class Subscription(Resource):
         cancellation_dates = fields.List(fields.DateTime(), allow_none=True)
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Subscription(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()
 
     # /import has different paging
     @classmethod
     def _loadJSON(cls, jsonObj):
         if "subscriptions" in jsonObj:
             _many = namedtuple('Subscriptions', ["subscriptions", "current_page", "total_pages", "customer_uuid"])
-            return _many(cls._schema.load(jsonObj["subscriptions"], many=True).data,
+            return _many(cls._schema.load(jsonObj["subscriptions"], many=True),
                          jsonObj["current_page"],
                          jsonObj["total_pages"],
                          jsonObj["customer_uuid"])

--- a/chartmogul/api/tags.py
+++ b/chartmogul/api/tags.py
@@ -14,11 +14,11 @@ class Tags(Resource):
         tags = fields.List(fields.String())
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Tags(**data)
 
     _customers = namedtuple('Customers', ['entries'])
-    _schema = _Schema(strict=True)
+    _schema = _Schema()
 
     @classmethod
     def _load(cls, response):
@@ -31,7 +31,7 @@ class Tags(Resource):
             return None
         jsonObj = response.json()
         if 'entries' in jsonObj:
-            customers = Customer._schema.load(jsonObj['entries'], many=True).data
+            customers = Customer._schema.load(jsonObj['entries'], many=True)
             return cls._customers(customers)
         else:
-            return cls._schema.load(jsonObj).data
+            return cls._schema.load(jsonObj)

--- a/chartmogul/api/transaction.py
+++ b/chartmogul/api/transaction.py
@@ -17,7 +17,7 @@ class Transaction(Resource):
         result = fields.String()
 
         @post_load
-        def make(self, data):
+        def make(self, data, **kwargs):
             return Transaction(**data)
 
-    _schema = _Schema(strict=True)
+    _schema = _Schema()

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -1,12 +1,14 @@
-import requests
+from builtins import str
+from datetime import date, datetime
 from json import dumps
+
+import requests
 from promise import Promise
 from uritemplate import URITemplate
-from .retry_request import requests_retry_session
-from .errors import APIError, ConfigurationError, ArgumentMissingError, annotateHTTPError
+
 from .api.config import Config
-from datetime import datetime, date
-from builtins import str
+from .errors import APIError, ArgumentMissingError, ConfigurationError, annotateHTTPError
+from .retry_request import requests_retry_session
 
 """
 HTTP verb mapping. Based on nodejs library.
@@ -96,10 +98,10 @@ class Resource(DataObject):
     def _loadJSON(cls, jsonObj):
         # has load_many capability & is many entries result?
         if '_root_key' in dir(cls) is not None and cls._root_key in jsonObj:
-            return cls._many(cls._schema.load(jsonObj[cls._root_key], many=True).data,
+            return cls._many(cls._schema.load(jsonObj[cls._root_key], many=True),
                              **{key: jsonObj[key] for key in LIST_PARAMS if key in jsonObj})
         else:
-            return cls._schema.load(jsonObj).data
+            return cls._schema.load(jsonObj)
 
     @classmethod
     def _preProcessParams(cls, params):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.10.0
 uritemplate>=3.0.0
 promise>=1.0.1
-marshmallow>=2.12.1,<3
+marshmallow>=3.10.0
 future>=0.16.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requires = [
     'requests>=2.10.0',
     'uritemplate>=3.0.0',
     'promise>=1.0.1',
-    'marshmallow>=2.12.1,<3',
+    'marshmallow>=3.10.0',
     'future>=0.16.0',
 ]
 test_requirements = [


### PR DESCRIPTION
# What it does?
This change updates the Marshmallow package version from `>=2.12.1` to the latest `>=3.10.0` and fixes the incompatibilities between those versions. The Chartmogul version is also bumped from `1.4.1` to `1.5.0`.

# Why it has been done?
Marshmellow version previously used is not developed anymore and is missing many new features released under the new version. Dependency like that is very problematic especially if Chartmogul is used in a larger project and blocks the upgrades.

# Changes applied

List of changes performed based on the upgrade guide on the Marshmallow docs.

1. Data is returned by default or exception is raised if validation unsuccessful ([docs](https://marshmallow.readthedocs.io/en/stable/upgrading.html#schemas-are-always-strict)). Example:
```diff
-            return cls._schema.load(jsonObj).data
+            return cls._schema.load(jsonObj)
```
2. Schemas are always strict ([docs](https://marshmallow.readthedocs.io/en/stable/upgrading.html#schemas-are-always-strict)). Example:
```diff
-    _schema = _Schema(strict=True)
+    _schema = _Schema()
```
3. Additional argument `many` is being passed to the `post_load` handlers ([docs](https://marshmallow.readthedocs.io/en/stable/upgrading.html#pre-processing-and-post-processing-methods)). Example:
```diff
-        def make(self, data):
+        def make(self, data, **kwargs):
```
4. `load_from` and `dump_to` are merged into data_key ([docs](https://marshmallow.readthedocs.io/en/stable/upgrading.html#load-from-and-dump-to-are-merged-into-data-key)). Example: 
```diff
-        percentage_change = fields.Number(load_from='percentage-change')
+        percentage_change = fields.Number(data_key='percentage-change')
```

5. `description` field was missing in the `api/invoice.py::LineItem`

Closes #38 