### PR TITLE
Add Account API endpoint [ch28502]

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ chartmogul.Activity.all(config, uuid='')
 chartmogul.Subscription.all(config, uuid='')
 ```
 
+### Account
+
+Available methods:
+
+```python
+chartmogul.Account.retrieve(config)
+```
+
 
 ### Errors
 

--- a/chartmogul/__init__.py
+++ b/chartmogul/__init__.py
@@ -15,6 +15,7 @@ from .api.plan_group import PlanGroup
 from .api.subscription import Subscription
 from .api.tags import Tags
 from .api.transaction import Transaction
+from .api.account import Account
 
 # Deprecated
 import imp
@@ -30,7 +31,7 @@ Provides convenient Python bindings for ChartMogul's API.
 """
 
 __title__ = 'chartmogul'
-__version__ = '1.5.0'
+__version__ = '1.5.1'
 __build__ = 0x000000
 __author__ = 'ChartMogul Ltd'
 __license__ = 'MIT'

--- a/chartmogul/__init__.py
+++ b/chartmogul/__init__.py
@@ -31,7 +31,7 @@ Provides convenient Python bindings for ChartMogul's API.
 """
 
 __title__ = 'chartmogul'
-__version__ = '1.5.1'
+__version__ = '1.6.0'
 __build__ = 0x000000
 __author__ = 'ChartMogul Ltd'
 __license__ = 'MIT'

--- a/chartmogul/api/account.py
+++ b/chartmogul/api/account.py
@@ -1,0 +1,26 @@
+from marshmallow import Schema, fields, post_load
+from ..resource import Resource
+
+from .config import Config
+
+
+class Account(Resource):
+    """
+    https://dev.chartmogul.com/v1.0/reference#account
+    """
+    _path = "/account"
+
+    class _Schema(Schema):
+        name = fields.String()
+        currency = fields.String()
+        time_zone = fields.String()
+        week_start_on = fields.String()
+
+        @post_load
+        def make(self, data, **kwargs):
+            return Account(**data)
+
+    _schema = _Schema()
+
+
+Account.retrieve = Account._method('retrieve', 'get', '/account')

--- a/chartmogul/api/account.py
+++ b/chartmogul/api/account.py
@@ -22,5 +22,7 @@ class Account(Resource):
 
     _schema = _Schema()
 
-
-Account.retrieve = Account._method('retrieve', 'get', '/account')
+    @classmethod
+    def _validate_arguments(cls, method, kwargs):
+        # no need for uuid validation on account
+        return

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -138,6 +138,16 @@ class Resource(DataObject):
 
     @classmethod
     def _method(cls, method, http_verb, path=None):
+        def validate_arguments(**kwargs):
+            # This enforces user to pass argument, otherwise we could call
+            # wrong URL.
+            if method in ['destroy', 'cancel', 'retrieve', 'update'] and 'uuid' not in kwargs:
+                raise ArgumentMissingError("Please pass 'uuid' parameter")
+            if method in ['create', 'modify'] and 'data' not in kwargs:
+                raise ArgumentMissingError("Please pass 'data' parameter")
+            if method in ['destroy_all'] and 'data_source_uuid' not in kwargs and 'customer_uuid' not in kwargs:
+                raise ArgumentMissingError("Please pass 'data_source_uuid' and 'customer_uuid' parameters")
+
         @classmethod
         def fc(cls, config, **kwargs):
             if config is None or not isinstance(config, Config):
@@ -148,14 +158,8 @@ class Resource(DataObject):
             if pathTemp is None:
                 pathTemp = cls._path
 
-            # This enforces user to pass argument, otherwise we could call
-            # wrong URL.
-            if method in ['destroy', 'cancel', 'retrieve', 'update'] and 'uuid' not in kwargs:
-                raise ArgumentMissingError("Please pass 'uuid' parameter")
-            if method in ['create', 'modify'] and 'data' not in kwargs:
-                raise ArgumentMissingError("Please pass 'data' parameter")
-            if method in ['destroy_all'] and 'data_source_uuid' not in kwargs and 'customer_uuid' not in kwargs:
-                raise ArgumentMissingError("Please pass 'data_source_uuid' and 'customer_uuid' parameters")
+            if cls.__name__ != 'Account':
+                validate_arguments(**kwargs)
 
             pathTemp = Resource._expandPath(pathTemp, kwargs)
             # UUID is always path parameter only.

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -137,17 +137,18 @@ class Resource(DataObject):
         return t.expand(kwargs)
 
     @classmethod
-    def _method(cls, method, http_verb, path=None):
-        def validate_arguments(**kwargs):
-            # This enforces user to pass argument, otherwise we could call
-            # wrong URL.
-            if method in ['destroy', 'cancel', 'retrieve', 'update'] and 'uuid' not in kwargs:
-                raise ArgumentMissingError("Please pass 'uuid' parameter")
-            if method in ['create', 'modify'] and 'data' not in kwargs:
-                raise ArgumentMissingError("Please pass 'data' parameter")
-            if method in ['destroy_all'] and 'data_source_uuid' not in kwargs and 'customer_uuid' not in kwargs:
-                raise ArgumentMissingError("Please pass 'data_source_uuid' and 'customer_uuid' parameters")
+    def _validate_arguments(cls, method, kwargs):
+        # This enforces user to pass argument, otherwise we could call
+        # wrong URL.
+        if method in ['destroy', 'cancel', 'retrieve', 'update'] and 'uuid' not in kwargs:
+            raise ArgumentMissingError("Please pass 'uuid' parameter")
+        if method in ['create', 'modify'] and 'data' not in kwargs:
+            raise ArgumentMissingError("Please pass 'data' parameter")
+        if method in ['destroy_all'] and 'data_source_uuid' not in kwargs and 'customer_uuid' not in kwargs:
+            raise ArgumentMissingError("Please pass 'data_source_uuid' and 'customer_uuid' parameters")
 
+    @classmethod
+    def _method(cls, method, http_verb, path=None):
         @classmethod
         def fc(cls, config, **kwargs):
             if config is None or not isinstance(config, Config):
@@ -158,8 +159,7 @@ class Resource(DataObject):
             if pathTemp is None:
                 pathTemp = cls._path
 
-            if cls.__name__ != 'Account':
-                validate_arguments(**kwargs)
+            cls._validate_arguments(method, kwargs)
 
             pathTemp = Resource._expandPath(pathTemp, kwargs)
             # UUID is always path parameter only.

--- a/docs/chartmogul.api.rst
+++ b/docs/chartmogul.api.rst
@@ -52,6 +52,14 @@ chartmogul.api.plan_group module
     :undoc-members:
     :show-inheritance:
 
+chartmogul.api.account module
+--------------------------
+
+.. automodule:: chartmogul.api.account
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/docs/test.api.rst
+++ b/docs/test.api.rst
@@ -76,6 +76,14 @@ test.api.test_tags module
     :undoc-members:
     :show-inheritance:
 
+test.api.test_account module
+-------------------------
+
+.. automodule:: test.api.test_account
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -44,6 +44,15 @@ test.test_plan_group module
     :undoc-members:
     :show-inheritance:
 
+test.test_account module
+---------------------
+
+.. automodule:: test.test_account
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Module contents
 ---------------
 

--- a/test/api/test_account.py
+++ b/test/api/test_account.py
@@ -1,0 +1,36 @@
+import unittest
+
+import requests_mock
+
+from chartmogul import Account, Config, APIError
+
+
+jsonResponse = {
+  "name": u"Example Test Company",
+  "currency": u"EUR",
+  "time_zone": u"Europe/Berlin",
+  "week_start_on": u"sunday"
+}
+
+
+class AccountTestCase(unittest.TestCase):
+    """
+    Tests account endpoint.
+    """
+    @requests_mock.mock()
+    def test_retrieve(self, mock_requests):
+        mock_requests.register_uri(
+            'GET',
+            "https://api.chartmogul.com/v1/account",
+            request_headers={'Authorization': 'Basic dG9rZW46c2VjcmV0'},
+            status_code=200,
+            json=jsonResponse
+        )
+
+        config = Config("token", "secret")  # is actually checked in mock
+        account = Account.retrieve(config).get()
+        self.assertTrue(isinstance(account, Account))
+        self.assertEqual(account.name, "Example Test Company")
+        self.assertEqual(account.currency, "EUR")
+        self.assertEqual(account.time_zone, "Europe/Berlin")
+        self.assertEqual(account.week_start_on, "sunday")


### PR DESCRIPTION
### Account Endpoint

```python
chartmogul.Account.retrieve(config)
```

Makes the following account-level details available via API call:
- name
- time zone
- currency
- week start on

Find more information [here](https://www.notion.so/chartmogul/WIP-App-Make-account-details-available-via-API-calls-379e0e91d8d94a37ae04ffdfcf57c8c7) on Notion.

[https://app.clubhouse.io/chartmogul/story/28502/update-libraries-for-account-api-endpoints](https://app.clubhouse.io/chartmogul/story/28502/update-libraries-for-account-api-endpoints)