### PR TITLE
Compatibility with future API versions [ch33382]

### DIFF
--- a/chartmogul/__init__.py
+++ b/chartmogul/__init__.py
@@ -33,7 +33,7 @@ Provides convenient Python bindings for ChartMogul's API.
 """
 
 __title__ = 'chartmogul'
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 __build__ = 0x000000
 __author__ = 'ChartMogul Ltd'
 __license__ = 'MIT'

--- a/chartmogul/api/account.py
+++ b/chartmogul/api/account.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import Resource
 
 
@@ -18,7 +18,7 @@ class Account(Resource):
         def make(self, data, **kwargs):
             return Account(**data)
 
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)
 
     @classmethod
     def _validate_arguments(cls, method, kwargs):

--- a/chartmogul/api/attributes.py
+++ b/chartmogul/api/attributes.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import Resource
 
 
@@ -18,4 +18,4 @@ class Attributes(Resource):
         def make(self, data, **kwargs):
             return Attributes(**data)
 
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)

--- a/chartmogul/api/custom_attrs.py
+++ b/chartmogul/api/custom_attrs.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import Resource
 from .customer import Customer
 from collections import namedtuple
@@ -18,7 +18,7 @@ class CustomAttributes(Resource):
             return CustomAttributes(**data)
 
     _customers = namedtuple('Customers', ['entries'])
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)
 
     @classmethod
     def _load(cls, response):

--- a/chartmogul/api/customer.py
+++ b/chartmogul/api/customer.py
@@ -5,7 +5,7 @@ proper types (eg. parsed dates instead of strings). Creating customer only
 requires Customer class and simple dict/array data.
 Validation is done on server.
 """
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import DataObject, Resource
 from collections import namedtuple
 from .attributes import Attributes
@@ -48,7 +48,7 @@ class Customer(Resource):
         free_trial_started_at = fields.DateTime(allow_none=True)
 
         # Things that differ between create/update & retrieve/list
-        attributes = fields.Nested(Attributes._Schema)
+        attributes = fields.Nested(Attributes._Schema, unknown=EXCLUDE)
 
         # Retrieve/List only
         id = fields.Int()
@@ -64,13 +64,13 @@ class Customer(Resource):
         billing_system_type = fields.String(data_key="billing-system-type")
         currency = fields.String()
         currency_sign = fields.String(data_key="currency-sign")
-        address = fields.Nested(Address._Schema, allow_none=True)
+        address = fields.Nested(Address._Schema, allow_none=True, unknown=EXCLUDE)
 
         @post_load
         def make(self, data, **kwargs):
             return Customer(**data)
 
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)
 
 
 Customer.search = Customer._method('all', 'get', '/customers/search')

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import Resource, DataObject
 from .transaction import Transaction
 from collections import namedtuple
@@ -21,8 +21,10 @@ class LineItem(DataObject):
         quantity = fields.Int()
         discount_code = fields.String(allow_none=True)
         discount_amount_in_cents = fields.Int()
+        discount_description = fields.String(allow_none=True)
         tax_amount_in_cents = fields.Int()
         transaction_fees_in_cents = fields.Int()
+        transaction_fees_currency = fields.String(allow_none=True)
         account_code = fields.String(allow_none=True)
         description = fields.String(allow_none=True)
 
@@ -51,14 +53,14 @@ class Invoice(Resource):
         date = fields.DateTime()
         due_date = fields.DateTime(allow_none=True)
 
-        line_items = fields.Nested(LineItem._Schema, many=True)
-        transactions = fields.Nested(Transaction._Schema, many=True)
+        line_items = fields.Nested(LineItem._Schema, many=True, unknown=EXCLUDE)
+        transactions = fields.Nested(Transaction._Schema, many=True, unknown=EXCLUDE)
 
         @post_load
         def make(self, data, **kwargs):
             return Invoice(**data)
 
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)
 
     @classmethod
     def all(cls, config, **kwargs):

--- a/chartmogul/api/metrics.py
+++ b/chartmogul/api/metrics.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import Resource, DataObject, _add_method
 from collections import namedtuple
 
@@ -16,7 +16,7 @@ class Summary(DataObject):
         def make(self, data, **kwargs):
             return Summary(**data)
 
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)
 
 
 class Metrics(Resource):

--- a/chartmogul/api/ping.py
+++ b/chartmogul/api/ping.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import Resource, _add_method
 
 
@@ -15,7 +15,7 @@ class Ping(Resource):
         def make(self, data, **kwargs):
             return Ping(**data)
 
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)
 
 
 _add_method(Ping, "ping", "get")

--- a/chartmogul/api/plan.py
+++ b/chartmogul/api/plan.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import Resource
 from collections import namedtuple
 
@@ -23,4 +23,4 @@ class Plan(Resource):
         def make(self, data, **kwargs):
             return Plan(**data)
 
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)

--- a/chartmogul/api/plan_group.py
+++ b/chartmogul/api/plan_group.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import Resource
 from .plan_group_plans import PlanGroupPlans
 from collections import namedtuple
@@ -21,7 +21,7 @@ class PlanGroup(Resource):
         def make(self, data, **kwargs):
             return PlanGroup(**data)
 
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)
 
     @classmethod
     def all(cls, config, **kwargs):

--- a/chartmogul/api/plan_group_plans.py
+++ b/chartmogul/api/plan_group_plans.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import Resource
 from collections import namedtuple
 
@@ -23,4 +23,4 @@ class PlanGroupPlans(Resource):
         def make(self, data, **kwargs):
             return PlanGroupPlans(**data)
 
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)

--- a/chartmogul/api/tags.py
+++ b/chartmogul/api/tags.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import Resource
 from .customer import Customer
 from collections import namedtuple
@@ -18,7 +18,7 @@ class Tags(Resource):
             return Tags(**data)
 
     _customers = namedtuple('Customers', ['entries'])
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)
 
     @classmethod
     def _load(cls, response):

--- a/chartmogul/api/transaction.py
+++ b/chartmogul/api/transaction.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 from ..resource import Resource
 
 
@@ -20,4 +20,4 @@ class Transaction(Resource):
         def make(self, data, **kwargs):
             return Transaction(**data)
 
-    _schema = _Schema()
+    _schema = _Schema(unknown=EXCLUDE)

--- a/test/api/test_invoice.py
+++ b/test/api/test_invoice.py
@@ -42,7 +42,10 @@ requestData = {
                     "quantity": 1,
                     "discount_code": "PSO86",
                     "discount_amount_in_cents": 500,
-                    "tax_amount_in_cents": 450
+                    "tax_amount_in_cents": 450,
+                    "discount_description": "Special 20 % discount",
+                    "transaction_fees_in_cents": 50,
+                    "transaction_fees_currency": "CZK"
                 }
             ],
             "transactions": [
@@ -86,7 +89,10 @@ requestSerialized = {
                     "quantity": 1,
                     "discount_code": "PSO86",
                     "discount_amount_in_cents": 500,
-                    "tax_amount_in_cents": 450
+                    "tax_amount_in_cents": 450,
+                    "discount_description": "Special 20 % discount",
+                    "transaction_fees_in_cents": 50,
+                    "transaction_fees_currency": "CZK"
                 }
             ],
             "transactions": [
@@ -138,6 +144,9 @@ responseData = {
                     "tax_amount_in_cents": 450,
                     "account_code": None,
                     "plan_uuid": None,
+                    "discount_description": "Special 20 % discount",
+                    "transaction_fees_in_cents": 50,
+                    "transaction_fees_currency": "CZK"
                 }
             ],
             "transactions": [
@@ -146,7 +155,7 @@ responseData = {
                     "external_id": None,
                     "type": "payment",
                     "date": "2015-11-05T00:04:03.000Z",
-                    "result": "successful", 
+                    "result": "successful",
                     "amount_in_cents": 7500
                 }
             ]
@@ -191,7 +200,10 @@ newInvoiceListExample = """
           "discount_code": "PSO86",
           "discount_amount_in_cents": 500,
           "tax_amount_in_cents": 450,
-          "account_code": null
+          "account_code": null,
+          "discount_description": "Special 20 % discount",
+          "transaction_fees_in_cents": 50,
+          "transaction_fees_currency": "CZK"
         }
       ],
       "transactions": [
@@ -244,7 +256,10 @@ retrieveInvoiceExample = """
       "discount_code": "PSO86",
       "discount_amount_in_cents": 500,
       "tax_amount_in_cents": 450,
-      "account_code": null
+      "account_code": null,
+      "discount_description": "Special 20 % discount",
+      "transaction_fees_in_cents": 50,
+      "transaction_fees_currency": "CZK"
     }
   ],
   "transactions": [


### PR DESCRIPTION
This addresses issue #49 and leverages the suggested feature of Marshmallow parser - we will load new API payloads with unknown fields, but publish only known fields to the program. Upgrade of library needed when introducing a new field.

Situation now: even old library versions are failing, because there's a new field on API.

Alternative: use `INCLUDE`... however this could use wrong (raw JSON) type and adding the field could break programs relying on the field type automatically added.

I'd like to set this globally, but I don't know how, [except overloading the `OPTIONS_CLASS`](https://marshmallow.readthedocs.io/en/stable/extending.html#custom-class-meta-options), but that still needs to be written in every class...