### PR TITLE
Fix missing contact uuid

### DIFF
--- a/chartmogul/api/contact.py
+++ b/chartmogul/api/contact.py
@@ -13,6 +13,7 @@ class Contact(Resource):
                        [_root_key, "has_more", "cursor"])
 
     class _Schema(Schema):
+        uuid = fields.String()
         customer_uuid = fields.String(allow_none=True)
         data_source_uuid = fields.String(allow_none=True)
         customer_external_id = fields.String(allow_none=True)

--- a/test/api/test_contact.py
+++ b/test/api/test_contact.py
@@ -25,6 +25,7 @@ contact = {
 }
 
 createContact = {
+    "uuid": "con_00000000-0000-0000-0000-000000000000",
     "customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
     "data_source_uuid": "ds_00000000-0000-0000-0000-000000000000",
     "first_name": "First name",

--- a/test/api/test_customer.py
+++ b/test/api/test_customer.py
@@ -304,6 +304,7 @@ contact = {
 }
 
 createContact = {
+    "uuid": "con_00000000-0000-0000-0000-000000000000",
     "data_source_uuid": "ds_00000000-0000-0000-0000-000000000000",
     "first_name": "First name",
     "last_name": "Last name",


### PR DESCRIPTION
While reviewing the doc, I realized that the `uuid` field is missing from the contact's schema (but it's there in the response). It was left out in #72 . This should fix it