### PR TITLE
chore(requirements.txt): bump urllib3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [4.5.1] - 2025-04-07
+- Update urllib3 dependency to use >=2.2.3 to allow for future minor updates
+
 ## [4.5.0] - 2025-03-18
 - Adds support for disconnecting subscriptions
 - Adds support for transaction fees to transactions

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ uritemplate>=3.0.0
 promise>=1.0.1
 marshmallow>=3.19.0
 future>=0.18.3
-urllib3==2.2.2
+urllib3>=2.2.3


### PR DESCRIPTION
# Update urllib3 dependency to allow future minor updates

## Description
This PR updates the urllib3 dependency in `requirements.txt` to use `>=2.2.3` instead of `==2.2.3`. This change allows for future minor updates while maintaining compatibility with other dependencies.

## Changes
- Updated `requirements.txt` to use `urllib3>=2.2.3`
- Updated `CHANGELOG.md` to reflect this change in version 4.5.1

## Testing
- [x] Verified that the package installs correctly with the new dependency constraint
- [x] Ran existing test suite to ensure compatibility

## Related Issues
- This change helps prepare for future dependency updates while maintaining current compatibility
- Part of ongoing dependency management and security updates

## Release Notes
This change will be released as version 4.5.1, following semantic versioning principles as it's a backward-compatible dependency update.