### PR TITLE
Skip codeclimate report if env var not set

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,12 @@ jobs:
       - name: Run tests
         run: coverage run -m unittest && coverage xml -i --include='chartmogul/*'
       - name: Send Report to Code Climate
+        if: ${{ success() }}
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        if: ${{ success() }}
-        run: ./cc-test-reporter after-build -t coverage.py
-
+        run: |
+          if [ -z "$CC_TEST_REPORTER_ID" ]; then
+            echo "⚠️ Skipping Code Climate upload — CC_TEST_REPORTER_ID is not set."
+          else
+            ./cc-test-reporter after-build -t coverage.py
+          fi


### PR DESCRIPTION
If a contribution to this repo is made from a fork, like [this example](https://github.com/chartmogul/chartmogul-python/pull/104), this env variable will not be set. This results in test errors.

In this PR, if the env is not set, sending the codeclimate report is ignored.

Let me know if you agree.