### PR TITLE
Add missing features and new endpoints

### DIFF
--- a/chartmogul/__init__.py
+++ b/chartmogul/__init__.py
@@ -15,6 +15,7 @@ from .api.customer_note import CustomerNote
 from .api.contact import Contact
 from .api.data_source import DataSource
 from .api.invoice import Invoice
+from .api.line_item import LineItem
 from .api.metrics import Metrics
 from .api.opportunity import Opportunity
 from .api.task import Task

--- a/chartmogul/api/account.py
+++ b/chartmogul/api/account.py
@@ -10,10 +10,13 @@ class Account(Resource):
     _path = "/account"
 
     class _Schema(Schema):
+        id = fields.String(allow_none=True)
         name = fields.String()
         currency = fields.String()
         time_zone = fields.String()
         week_start_on = fields.String()
+        churn_recognition = fields.String(allow_none=True)
+        churn_when_zero_mrr = fields.String(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):

--- a/chartmogul/api/account.py
+++ b/chartmogul/api/account.py
@@ -16,7 +16,7 @@ class Account(Resource):
         time_zone = fields.String()
         week_start_on = fields.String()
         churn_recognition = fields.String(allow_none=True)
-        churn_when_zero_mrr = fields.String(allow_none=True)
+        churn_when_zero_mrr = fields.Raw(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -1,5 +1,5 @@
 from marshmallow import Schema, fields, post_load, EXCLUDE
-from ..resource import Resource, DataObject, _build_ext_id_params
+from ..resource import Resource, DataObject
 from .transaction import Transaction
 from collections import namedtuple
 
@@ -43,6 +43,7 @@ class Invoice(Resource):
     """
 
     _path = "/import/customers{/uuid}/invoices"
+    _ext_id_path = "/invoices"
     _root_key = "invoices"
     _bool_query_params = [
         'include_edit_histories',
@@ -93,43 +94,14 @@ class Invoice(Resource):
         else:
             return cls.all_any(config, **kwargs)
 
-    @classmethod
-    def retrieve(cls, config, **kwargs):
-        if "data_source_uuid" in kwargs and "external_id" in kwargs:
-            params = _build_ext_id_params(kwargs)
-            return cls._request(config, "retrieve", "get", "/invoices", query_params=params)
-        return cls._retrieve_by_uuid(config, **kwargs)
-
-    @classmethod
-    def destroy(cls, config, **kwargs):
-        if "data_source_uuid" in kwargs and "external_id" in kwargs:
-            params = _build_ext_id_params(kwargs)
-            return cls._request(config, "destroy", "delete", "/invoices", query_params=params)
-        return cls._destroy_by_uuid(config, **kwargs)
-
-    @classmethod
-    def update_status(cls, config, **kwargs):
-        if "data_source_uuid" in kwargs and "external_id" in kwargs:
-            params = _build_ext_id_params(kwargs)
-            return cls._request(config, "modify", "patch", "/invoices",
-                                data=kwargs.get("data"), query_params=params)
-        return cls._update_status_by_uuid(config, **kwargs)
-
-    @classmethod
-    def toggle_disabled(cls, config, **kwargs):
-        """PATCH /invoices/disabled_state with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "modify", "patch", "/invoices/disabled_state",
-                            data=kwargs.get("data"), query_params=params)
-
 
 Invoice.all_any = Invoice._method("all", "get", "/invoices")
-Invoice._destroy_by_uuid = Invoice._method("destroy", "delete", "/invoices{/uuid}")
+Invoice.destroy = Invoice._method("destroy", "delete", "/invoices{/uuid}")
 Invoice.destroy_all = Invoice._method(
     "destroy_all",
     "delete",
     "/data_sources{/data_source_uuid}/customers{/customer_uuid}/invoices",
 )
-Invoice._retrieve_by_uuid = Invoice._method("retrieve", "get", "/invoices{/uuid}")
-Invoice._update_status_by_uuid = Invoice._method("modify", "patch", "/invoices{/uuid}")
+Invoice.retrieve = Invoice._method("retrieve", "get", "/invoices{/uuid}")
+Invoice.update_status = Invoice._method("modify", "patch", "/invoices{/uuid}")
 Invoice.disable = Invoice._method("disable", "patch", "/invoices{/uuid}/disable")

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -46,7 +46,8 @@ class Invoice(Resource):
     _root_key = "invoices"
     _bool_query_params = [
         'include_edit_histories',
-        'with_disabled'
+        'with_disabled',
+        'handle_as_user_edit',
     ]
     _many = namedtuple(
         "Invoices",

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -89,7 +89,6 @@ class Invoice(Resource):
         else:
             return cls.all_any(config, **kwargs)
 
-
     @classmethod
     def retrieve_by_external_id(cls, config, **kwargs):
         """GET /invoices with data_source_uuid + external_id query params."""

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -99,4 +99,4 @@ Invoice.destroy_all = Invoice._method(
 )
 Invoice.retrieve = Invoice._method("retrieve", "get", "/invoices{/uuid}")
 Invoice.update_status = Invoice._method("modify", "patch", "/invoices{/uuid}")
-Invoice.disable = Invoice._method("patch", "patch", "/invoices{/uuid}/disable")
+Invoice.disable = Invoice._method("disable", "patch", "/invoices{/uuid}/disable")

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -28,6 +28,9 @@ class LineItem(DataObject):
         description = fields.String(allow_none=True)
         event_order = fields.Int(allow_none=True)
         errors = fields.Dict(allow_none=True)
+        disabled = fields.Boolean(allow_none=True)
+        disabled_at = fields.DateTime(allow_none=True)
+        disabled_by = fields.String(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):
@@ -90,26 +93,29 @@ class Invoice(Resource):
             return cls.all_any(config, **kwargs)
 
     @classmethod
-    def retrieve_by_external_id(cls, config, **kwargs):
-        """GET /invoices with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "retrieve", "get", "/invoices", query_params=params)
+    def retrieve(cls, config, **kwargs):
+        if "data_source_uuid" in kwargs and "external_id" in kwargs:
+            params = _build_ext_id_params(kwargs)
+            return cls._request(config, "retrieve", "get", "/invoices", query_params=params)
+        return cls._retrieve_by_uuid(config, **kwargs)
 
     @classmethod
-    def update_by_external_id(cls, config, **kwargs):
-        """PATCH /invoices with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "modify", "patch", "/invoices",
-                            data=kwargs.get("data"), query_params=params)
+    def destroy(cls, config, **kwargs):
+        if "data_source_uuid" in kwargs and "external_id" in kwargs:
+            params = _build_ext_id_params(kwargs)
+            return cls._request(config, "destroy", "delete", "/invoices", query_params=params)
+        return cls._destroy_by_uuid(config, **kwargs)
 
     @classmethod
-    def destroy_by_external_id(cls, config, **kwargs):
-        """DELETE /invoices with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "destroy", "delete", "/invoices", query_params=params)
+    def update_status(cls, config, **kwargs):
+        if "data_source_uuid" in kwargs and "external_id" in kwargs:
+            params = _build_ext_id_params(kwargs)
+            return cls._request(config, "modify", "patch", "/invoices",
+                                data=kwargs.get("data"), query_params=params)
+        return cls._update_status_by_uuid(config, **kwargs)
 
     @classmethod
-    def toggle_disabled_by_external_id(cls, config, **kwargs):
+    def toggle_disabled(cls, config, **kwargs):
         """PATCH /invoices/disabled_state with data_source_uuid + external_id query params."""
         params = _build_ext_id_params(kwargs)
         return cls._request(config, "modify", "patch", "/invoices/disabled_state",
@@ -117,12 +123,12 @@ class Invoice(Resource):
 
 
 Invoice.all_any = Invoice._method("all", "get", "/invoices")
-Invoice.destroy = Invoice._method("destroy", "delete", "/invoices{/uuid}")
+Invoice._destroy_by_uuid = Invoice._method("destroy", "delete", "/invoices{/uuid}")
 Invoice.destroy_all = Invoice._method(
     "destroy_all",
     "delete",
     "/data_sources{/data_source_uuid}/customers{/customer_uuid}/invoices",
 )
-Invoice.retrieve = Invoice._method("retrieve", "get", "/invoices{/uuid}")
-Invoice.update_status = Invoice._method("modify", "patch", "/invoices{/uuid}")
+Invoice._retrieve_by_uuid = Invoice._method("retrieve", "get", "/invoices{/uuid}")
+Invoice._update_status_by_uuid = Invoice._method("modify", "patch", "/invoices{/uuid}")
 Invoice.disable = Invoice._method("disable", "patch", "/invoices{/uuid}/disable")

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -98,3 +98,5 @@ Invoice.destroy_all = Invoice._method(
     "/data_sources{/data_source_uuid}/customers{/customer_uuid}/invoices",
 )
 Invoice.retrieve = Invoice._method("retrieve", "get", "/invoices{/uuid}")
+Invoice.update_status = Invoice._method("modify", "patch", "/invoices{/uuid}")
+Invoice.disable = Invoice._method("patch", "patch", "/invoices{/uuid}/disable")

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -1,5 +1,5 @@
 from marshmallow import Schema, fields, post_load, EXCLUDE
-from ..resource import Resource, DataObject
+from ..resource import Resource, DataObject, _build_ext_id_params
 from .transaction import Transaction
 from collections import namedtuple
 
@@ -88,6 +88,33 @@ class Invoice(Resource):
             return super(Invoice, cls).all(config, **kwargs)
         else:
             return cls.all_any(config, **kwargs)
+
+
+    @classmethod
+    def retrieve_by_external_id(cls, config, **kwargs):
+        """GET /invoices with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "retrieve", "get", "/invoices", query_params=params)
+
+    @classmethod
+    def update_by_external_id(cls, config, **kwargs):
+        """PATCH /invoices with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "modify", "patch", "/invoices",
+                            data=kwargs.get("data"), query_params=params)
+
+    @classmethod
+    def destroy_by_external_id(cls, config, **kwargs):
+        """DELETE /invoices with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "destroy", "delete", "/invoices", query_params=params)
+
+    @classmethod
+    def toggle_disabled_by_external_id(cls, config, **kwargs):
+        """PATCH /invoices/disabled_state with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "modify", "patch", "/invoices/disabled_state",
+                            data=kwargs.get("data"), query_params=params)
 
 
 Invoice.all_any = Invoice._method("all", "get", "/invoices")

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -104,4 +104,4 @@ Invoice.destroy_all = Invoice._method(
 )
 Invoice.retrieve = Invoice._method("retrieve", "get", "/invoices{/uuid}")
 Invoice.update_status = Invoice._method("modify", "patch", "/invoices{/uuid}")
-Invoice.disable = Invoice._method("disable", "patch", "/invoices{/uuid}/disable")
+Invoice.disable = Invoice._method("disable", "patch", "/invoices{/uuid}/disabled_state")

--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -27,6 +27,7 @@ class LineItem(DataObject):
         account_code = fields.String(allow_none=True)
         description = fields.String(allow_none=True)
         event_order = fields.Int(allow_none=True)
+        errors = fields.Dict(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):

--- a/chartmogul/api/line_item.py
+++ b/chartmogul/api/line_item.py
@@ -1,0 +1,70 @@
+from marshmallow import Schema, fields, post_load, EXCLUDE
+from ..resource import Resource, _build_ext_id_params
+
+
+class LineItem(Resource):
+    """
+    https://dev.chartmogul.com/reference/line-items
+    Standalone resource for line item operations by external_id + data_source_uuid.
+    """
+
+    _path = "/line_items"
+
+    class _Schema(Schema):
+        uuid = fields.String()
+        external_id = fields.String(allow_none=True)
+        type = fields.String()
+        subscription_uuid = fields.String(allow_none=True)
+        subscription_external_id = fields.String(allow_none=True)
+        subscription_set_external_id = fields.String(allow_none=True)
+        plan_uuid = fields.String(allow_none=True)
+        prorated = fields.Boolean()
+        service_period_start = fields.DateTime(allow_none=True)
+        service_period_end = fields.DateTime(allow_none=True)
+        amount_in_cents = fields.Int()
+        quantity = fields.Int()
+        discount_code = fields.String(allow_none=True)
+        discount_amount_in_cents = fields.Int()
+        discount_description = fields.String(allow_none=True)
+        tax_amount_in_cents = fields.Int()
+        transaction_fees_in_cents = fields.Int()
+        transaction_fees_currency = fields.String(allow_none=True)
+        account_code = fields.String(allow_none=True)
+        description = fields.String(allow_none=True)
+        event_order = fields.Int(allow_none=True)
+        errors = fields.Dict(allow_none=True)
+        disabled = fields.Boolean(allow_none=True)
+        disabled_at = fields.DateTime(allow_none=True)
+        disabled_by = fields.String(allow_none=True)
+
+        @post_load
+        def make(self, data, **kwargs):
+            return LineItem(**data)
+
+    _schema = _Schema(unknown=EXCLUDE)
+
+    @classmethod
+    def retrieve_by_external_id(cls, config, **kwargs):
+        """GET /line_items with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "retrieve", "get", "/line_items", query_params=params)
+
+    @classmethod
+    def update_by_external_id(cls, config, **kwargs):
+        """PATCH /line_items with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "modify", "patch", "/line_items",
+                            data=kwargs.get("data"), query_params=params)
+
+    @classmethod
+    def destroy_by_external_id(cls, config, **kwargs):
+        """DELETE /line_items with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "destroy", "delete", "/line_items", query_params=params)
+
+    @classmethod
+    def toggle_disabled_by_external_id(cls, config, **kwargs):
+        """PATCH /line_items/disabled_state with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "modify", "patch", "/line_items/disabled_state",
+                            data=kwargs.get("data"), query_params=params)

--- a/chartmogul/api/line_item.py
+++ b/chartmogul/api/line_item.py
@@ -1,5 +1,5 @@
 from marshmallow import Schema, fields, post_load, EXCLUDE
-from ..resource import Resource, _build_ext_id_params
+from ..resource import Resource
 
 
 class LineItem(Resource):
@@ -9,6 +9,7 @@ class LineItem(Resource):
     """
 
     _path = "/line_items"
+    _ext_id_path = "/line_items"
     _bool_query_params = ['handle_as_user_edit']
 
     class _Schema(Schema):
@@ -44,28 +45,7 @@ class LineItem(Resource):
 
     _schema = _Schema(unknown=EXCLUDE)
 
-    @classmethod
-    def retrieve(cls, config, **kwargs):
-        """GET /line_items with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "retrieve", "get", "/line_items", query_params=params)
 
-    @classmethod
-    def modify(cls, config, **kwargs):
-        """PATCH /line_items with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "modify", "patch", "/line_items",
-                            data=kwargs.get("data"), query_params=params)
-
-    @classmethod
-    def destroy(cls, config, **kwargs):
-        """DELETE /line_items with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "destroy", "delete", "/line_items", query_params=params)
-
-    @classmethod
-    def toggle_disabled(cls, config, **kwargs):
-        """PATCH /line_items/disabled_state with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "modify", "patch", "/line_items/disabled_state",
-                            data=kwargs.get("data"), query_params=params)
+LineItem.retrieve = LineItem._method("retrieve", "get", "/line_items")
+LineItem.modify = LineItem._method("modify", "patch", "/line_items")
+LineItem.destroy = LineItem._method("destroy", "delete", "/line_items")

--- a/chartmogul/api/line_item.py
+++ b/chartmogul/api/line_item.py
@@ -46,6 +46,10 @@ class LineItem(Resource):
     _schema = _Schema(unknown=EXCLUDE)
 
 
+LineItem.create = LineItem._method(
+    "create", "post", "/import/invoices{/uuid}/line_items")
 LineItem.retrieve = LineItem._method("retrieve", "get", "/line_items{/uuid}")
 LineItem.modify = LineItem._method("modify", "patch", "/line_items{/uuid}")
 LineItem.destroy = LineItem._method("destroy", "delete", "/line_items{/uuid}")
+LineItem.disable = LineItem._method(
+    "disable", "patch", "/line_items{/uuid}/disabled_state")

--- a/chartmogul/api/line_item.py
+++ b/chartmogul/api/line_item.py
@@ -46,6 +46,6 @@ class LineItem(Resource):
     _schema = _Schema(unknown=EXCLUDE)
 
 
-LineItem.retrieve = LineItem._method("retrieve", "get", "/line_items")
-LineItem.modify = LineItem._method("modify", "patch", "/line_items")
-LineItem.destroy = LineItem._method("destroy", "delete", "/line_items")
+LineItem.retrieve = LineItem._method("retrieve", "get", "/line_items{/uuid}")
+LineItem.modify = LineItem._method("modify", "patch", "/line_items{/uuid}")
+LineItem.destroy = LineItem._method("destroy", "delete", "/line_items{/uuid}")

--- a/chartmogul/api/line_item.py
+++ b/chartmogul/api/line_item.py
@@ -9,6 +9,7 @@ class LineItem(Resource):
     """
 
     _path = "/line_items"
+    _bool_query_params = ['handle_as_user_edit']
 
     class _Schema(Schema):
         uuid = fields.String()
@@ -44,26 +45,26 @@ class LineItem(Resource):
     _schema = _Schema(unknown=EXCLUDE)
 
     @classmethod
-    def retrieve_by_external_id(cls, config, **kwargs):
+    def retrieve(cls, config, **kwargs):
         """GET /line_items with data_source_uuid + external_id query params."""
         params = _build_ext_id_params(kwargs)
         return cls._request(config, "retrieve", "get", "/line_items", query_params=params)
 
     @classmethod
-    def update_by_external_id(cls, config, **kwargs):
+    def modify(cls, config, **kwargs):
         """PATCH /line_items with data_source_uuid + external_id query params."""
         params = _build_ext_id_params(kwargs)
         return cls._request(config, "modify", "patch", "/line_items",
                             data=kwargs.get("data"), query_params=params)
 
     @classmethod
-    def destroy_by_external_id(cls, config, **kwargs):
+    def destroy(cls, config, **kwargs):
         """DELETE /line_items with data_source_uuid + external_id query params."""
         params = _build_ext_id_params(kwargs)
         return cls._request(config, "destroy", "delete", "/line_items", query_params=params)
 
     @classmethod
-    def toggle_disabled_by_external_id(cls, config, **kwargs):
+    def toggle_disabled(cls, config, **kwargs):
         """PATCH /line_items/disabled_state with data_source_uuid + external_id query params."""
         params = _build_ext_id_params(kwargs)
         return cls._request(config, "modify", "patch", "/line_items/disabled_state",

--- a/chartmogul/api/subscription_event.py
+++ b/chartmogul/api/subscription_event.py
@@ -69,9 +69,12 @@ def _modify(cls, config, **kwargs):
 @classmethod
 def _disable(cls, config, **kwargs):
     """Disable a subscription event by setting disabled to true."""
-    data = kwargs.get("data", {})
-    data["disabled"] = True
-    if "subscription_event" not in data:
+    data = dict(kwargs.get("data", {}))
+    if "subscription_event" in data:
+        data = {"subscription_event": dict(data["subscription_event"])}
+        data["subscription_event"]["disabled"] = True
+    else:
+        data["disabled"] = True
         data = {"subscription_event": data}
     return cls.modify_with_params(config, data=data)
 
@@ -79,9 +82,12 @@ def _disable(cls, config, **kwargs):
 @classmethod
 def _enable(cls, config, **kwargs):
     """Enable a subscription event by setting disabled to false."""
-    data = kwargs.get("data", {})
-    data["disabled"] = False
-    if "subscription_event" not in data:
+    data = dict(kwargs.get("data", {}))
+    if "subscription_event" in data:
+        data = {"subscription_event": dict(data["subscription_event"])}
+        data["subscription_event"]["disabled"] = False
+    else:
+        data["disabled"] = False
         data = {"subscription_event": data}
     return cls.modify_with_params(config, data=data)
 

--- a/chartmogul/api/subscription_event.py
+++ b/chartmogul/api/subscription_event.py
@@ -31,12 +31,53 @@ class SubscriptionEvent(Resource):
         retracted_event_id = fields.String(allow_none=True)
         external_id = fields.String(allow_none=True)
         event_order = fields.Int(allow_none=True)
+        disabled = fields.Bool(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):
             return SubscriptionEvent(**data)
 
     _schema = _Schema(unknown=EXCLUDE)
+
+    @classmethod
+    def destroy(cls, config, **kwargs):
+        """Accept flat params and wrap in subscription_event envelope for the API."""
+        data = dict(kwargs.get("data", {}))
+        if "subscription_event" not in data:
+            data = {"subscription_event": data}
+        return cls.destroy_with_params(config, data=data)
+
+    @classmethod
+    def modify(cls, config, **kwargs):
+        """Accept flat params and wrap in subscription_event envelope for the API."""
+        data = dict(kwargs.get("data", {}))
+        if "subscription_event" not in data:
+            data = {"subscription_event": data}
+        return cls.modify_with_params(config, data=data)
+
+    @classmethod
+    def disable(cls, config, **kwargs):
+        """Disable a subscription event by setting disabled to true."""
+        data = dict(kwargs.get("data", {}))
+        if "subscription_event" in data:
+            data = {"subscription_event": dict(data["subscription_event"])}
+            data["subscription_event"]["disabled"] = True
+        else:
+            data["disabled"] = True
+            data = {"subscription_event": data}
+        return cls.modify_with_params(config, data=data)
+
+    @classmethod
+    def enable(cls, config, **kwargs):
+        """Enable a subscription event by setting disabled to false."""
+        data = dict(kwargs.get("data", {}))
+        if "subscription_event" in data:
+            data = {"subscription_event": dict(data["subscription_event"])}
+            data["subscription_event"]["disabled"] = False
+        else:
+            data["disabled"] = False
+            data = {"subscription_event": data}
+        return cls.modify_with_params(config, data=data)
 
 
 SubscriptionEvent.all = SubscriptionEvent._method("all", "get", "/subscription_events")
@@ -46,53 +87,3 @@ SubscriptionEvent.destroy_with_params = SubscriptionEvent._method(
 SubscriptionEvent.modify_with_params = SubscriptionEvent._method(
     "modify_with_params", "patch", "/subscription_events"
 )
-
-
-@classmethod
-def _destroy(cls, config, **kwargs):
-    """Accept flat params and wrap in subscription_event envelope for the API."""
-    data = kwargs.get("data", {})
-    if "subscription_event" not in data:
-        data = {"subscription_event": data}
-    return cls.destroy_with_params(config, data=data)
-
-
-@classmethod
-def _modify(cls, config, **kwargs):
-    """Accept flat params and wrap in subscription_event envelope for the API."""
-    data = kwargs.get("data", {})
-    if "subscription_event" not in data:
-        data = {"subscription_event": data}
-    return cls.modify_with_params(config, data=data)
-
-
-@classmethod
-def _disable(cls, config, **kwargs):
-    """Disable a subscription event by setting disabled to true."""
-    data = dict(kwargs.get("data", {}))
-    if "subscription_event" in data:
-        data = {"subscription_event": dict(data["subscription_event"])}
-        data["subscription_event"]["disabled"] = True
-    else:
-        data["disabled"] = True
-        data = {"subscription_event": data}
-    return cls.modify_with_params(config, data=data)
-
-
-@classmethod
-def _enable(cls, config, **kwargs):
-    """Enable a subscription event by setting disabled to false."""
-    data = dict(kwargs.get("data", {}))
-    if "subscription_event" in data:
-        data = {"subscription_event": dict(data["subscription_event"])}
-        data["subscription_event"]["disabled"] = False
-    else:
-        data["disabled"] = False
-        data = {"subscription_event": data}
-    return cls.modify_with_params(config, data=data)
-
-
-SubscriptionEvent.destroy = _destroy
-SubscriptionEvent.modify = _modify
-SubscriptionEvent.disable = _disable
-SubscriptionEvent.enable = _enable

--- a/chartmogul/api/subscription_event.py
+++ b/chartmogul/api/subscription_event.py
@@ -46,3 +46,47 @@ SubscriptionEvent.destroy_with_params = SubscriptionEvent._method(
 SubscriptionEvent.modify_with_params = SubscriptionEvent._method(
     "modify_with_params", "patch", "/subscription_events"
 )
+
+
+@classmethod
+def _destroy(cls, config, **kwargs):
+    """Accept flat params and wrap in subscription_event envelope for the API."""
+    data = kwargs.get("data", {})
+    if "subscription_event" not in data:
+        data = {"subscription_event": data}
+    return cls.destroy_with_params(config, data=data)
+
+
+@classmethod
+def _modify(cls, config, **kwargs):
+    """Accept flat params and wrap in subscription_event envelope for the API."""
+    data = kwargs.get("data", {})
+    if "subscription_event" not in data:
+        data = {"subscription_event": data}
+    return cls.modify_with_params(config, data=data)
+
+
+@classmethod
+def _disable(cls, config, **kwargs):
+    """Disable a subscription event by setting disabled to true."""
+    data = kwargs.get("data", {})
+    data["disabled"] = True
+    if "subscription_event" not in data:
+        data = {"subscription_event": data}
+    return cls.modify_with_params(config, data=data)
+
+
+@classmethod
+def _enable(cls, config, **kwargs):
+    """Enable a subscription event by setting disabled to false."""
+    data = kwargs.get("data", {})
+    data["disabled"] = False
+    if "subscription_event" not in data:
+        data = {"subscription_event": data}
+    return cls.modify_with_params(config, data=data)
+
+
+SubscriptionEvent.destroy = _destroy
+SubscriptionEvent.modify = _modify
+SubscriptionEvent.disable = _disable
+SubscriptionEvent.enable = _enable

--- a/chartmogul/api/subscription_event.py
+++ b/chartmogul/api/subscription_event.py
@@ -41,11 +41,21 @@ class SubscriptionEvent(Resource):
 
     @classmethod
     def _wrap_envelope(cls, kwargs):
-        """Wrap flat params in subscription_event envelope if not already wrapped."""
+        """Wrap params in subscription_event envelope.
+
+        Supports three call styles (all backwards compatible):
+        1. New style:     (config, id=123, data={'amount': 2000})
+        2. Flat style:    (config, data={'id': 123, 'amount': 2000})
+        3. Envelope style:(config, data={'subscription_event': {'id': 123}})
+        """
         data = dict(kwargs.get("data", {}))
-        if "subscription_event" not in data:
-            data = {"subscription_event": data}
-        return data
+        if "subscription_event" in data:
+            return data
+        # Merge top-level id/external_id/data_source_uuid into data
+        for key in ("id", "external_id", "data_source_uuid"):
+            if key in kwargs:
+                data[key] = kwargs[key]
+        return {"subscription_event": data}
 
     @classmethod
     def destroy_with_params(cls, config, **kwargs):
@@ -65,6 +75,9 @@ class SubscriptionEvent(Resource):
         data = dict(kwargs.get("data", {}))
         if "subscription_event" in data:
             data = dict(data["subscription_event"])
+        for key in ("id", "external_id", "data_source_uuid"):
+            if key in kwargs:
+                data[key] = kwargs[key]
         data["disabled"] = True
         return cls.modify_with_params(config, data=data)
 
@@ -74,6 +87,9 @@ class SubscriptionEvent(Resource):
         data = dict(kwargs.get("data", {}))
         if "subscription_event" in data:
             data = dict(data["subscription_event"])
+        for key in ("id", "external_id", "data_source_uuid"):
+            if key in kwargs:
+                data[key] = kwargs[key]
         data["disabled"] = False
         return cls.modify_with_params(config, data=data)
 

--- a/chartmogul/api/subscription_event.py
+++ b/chartmogul/api/subscription_event.py
@@ -60,24 +60,18 @@ class SubscriptionEvent(Resource):
         """Disable a subscription event by setting disabled to true."""
         data = dict(kwargs.get("data", {}))
         if "subscription_event" in data:
-            data = {"subscription_event": dict(data["subscription_event"])}
-            data["subscription_event"]["disabled"] = True
-        else:
-            data["disabled"] = True
-            data = {"subscription_event": data}
-        return cls.modify_with_params(config, data=data)
+            data = dict(data["subscription_event"])
+        data["disabled"] = True
+        return cls.modify(config, data=data)
 
     @classmethod
     def enable(cls, config, **kwargs):
         """Enable a subscription event by setting disabled to false."""
         data = dict(kwargs.get("data", {}))
         if "subscription_event" in data:
-            data = {"subscription_event": dict(data["subscription_event"])}
-            data["subscription_event"]["disabled"] = False
-        else:
-            data["disabled"] = False
-            data = {"subscription_event": data}
-        return cls.modify_with_params(config, data=data)
+            data = dict(data["subscription_event"])
+        data["disabled"] = False
+        return cls.modify(config, data=data)
 
 
 SubscriptionEvent.all = SubscriptionEvent._method("all", "get", "/subscription_events")

--- a/chartmogul/api/subscription_event.py
+++ b/chartmogul/api/subscription_event.py
@@ -40,20 +40,24 @@ class SubscriptionEvent(Resource):
     _schema = _Schema(unknown=EXCLUDE)
 
     @classmethod
-    def destroy(cls, config, **kwargs):
-        """Accept flat params and wrap in subscription_event envelope for the API."""
+    def _wrap_envelope(cls, kwargs):
+        """Wrap flat params in subscription_event envelope if not already wrapped."""
         data = dict(kwargs.get("data", {}))
         if "subscription_event" not in data:
             data = {"subscription_event": data}
-        return cls.destroy_with_params(config, data=data)
+        return data
 
     @classmethod
-    def modify(cls, config, **kwargs):
-        """Accept flat params and wrap in subscription_event envelope for the API."""
-        data = dict(kwargs.get("data", {}))
-        if "subscription_event" not in data:
-            data = {"subscription_event": data}
-        return cls.modify_with_params(config, data=data)
+    def destroy_with_params(cls, config, **kwargs):
+        """DELETE /subscription_events. Accepts flat or envelope-wrapped params."""
+        kwargs["data"] = cls._wrap_envelope(kwargs)
+        return cls._destroy_raw(config, **kwargs)
+
+    @classmethod
+    def modify_with_params(cls, config, **kwargs):
+        """PATCH /subscription_events. Accepts flat or envelope-wrapped params."""
+        kwargs["data"] = cls._wrap_envelope(kwargs)
+        return cls._modify_raw(config, **kwargs)
 
     @classmethod
     def disable(cls, config, **kwargs):
@@ -62,7 +66,7 @@ class SubscriptionEvent(Resource):
         if "subscription_event" in data:
             data = dict(data["subscription_event"])
         data["disabled"] = True
-        return cls.modify(config, data=data)
+        return cls.modify_with_params(config, data=data)
 
     @classmethod
     def enable(cls, config, **kwargs):
@@ -71,13 +75,12 @@ class SubscriptionEvent(Resource):
         if "subscription_event" in data:
             data = dict(data["subscription_event"])
         data["disabled"] = False
-        return cls.modify(config, data=data)
+        return cls.modify_with_params(config, data=data)
 
 
-SubscriptionEvent.all = SubscriptionEvent._method("all", "get", "/subscription_events")
-SubscriptionEvent.destroy_with_params = SubscriptionEvent._method(
-    "destroy_with_params", "delete", "/subscription_events"
-)
-SubscriptionEvent.modify_with_params = SubscriptionEvent._method(
-    "modify_with_params", "patch", "/subscription_events"
-)
+SubscriptionEvent.all = SubscriptionEvent._method(
+    "all", "get", "/subscription_events")
+SubscriptionEvent._destroy_raw = SubscriptionEvent._method(
+    "destroy_with_params", "delete", "/subscription_events")
+SubscriptionEvent._modify_raw = SubscriptionEvent._method(
+    "modify_with_params", "patch", "/subscription_events")

--- a/chartmogul/api/transaction.py
+++ b/chartmogul/api/transaction.py
@@ -1,5 +1,5 @@
 from marshmallow import Schema, fields, post_load, EXCLUDE
-from ..resource import Resource, _build_ext_id_params
+from ..resource import Resource
 
 
 class Transaction(Resource):
@@ -8,6 +8,7 @@ class Transaction(Resource):
     """
 
     _path = "/import/invoices{/uuid}/transactions"
+    _ext_id_path = "/transactions"
     _bool_query_params = ['handle_as_user_edit']
 
     class _Schema(Schema):
@@ -30,41 +31,10 @@ class Transaction(Resource):
 
     _schema = _Schema(unknown=EXCLUDE)
 
-    @classmethod
-    def retrieve(cls, config, **kwargs):
-        if "data_source_uuid" in kwargs and "external_id" in kwargs:
-            params = _build_ext_id_params(kwargs)
-            return cls._request(config, "retrieve", "get", "/transactions",
-                                query_params=params)
-        return cls._retrieve_by_uuid(config, **kwargs)
 
-    @classmethod
-    def modify(cls, config, **kwargs):
-        if "data_source_uuid" in kwargs and "external_id" in kwargs:
-            params = _build_ext_id_params(kwargs)
-            return cls._request(config, "modify", "patch", "/transactions",
-                                data=kwargs.get("data"), query_params=params)
-        return cls._modify_by_uuid(config, **kwargs)
-
-    @classmethod
-    def destroy(cls, config, **kwargs):
-        if "data_source_uuid" in kwargs and "external_id" in kwargs:
-            params = _build_ext_id_params(kwargs)
-            return cls._request(config, "destroy", "delete", "/transactions",
-                                query_params=params)
-        return cls._destroy_by_uuid(config, **kwargs)
-
-    @classmethod
-    def toggle_disabled(cls, config, **kwargs):
-        """PATCH /transactions/disabled_state with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "modify", "patch", "/transactions/disabled_state",
-                            data=kwargs.get("data"), query_params=params)
-
-
-Transaction._retrieve_by_uuid = Transaction._method(
+Transaction.retrieve = Transaction._method(
     "retrieve", "get", "/transactions{/uuid}")
-Transaction._modify_by_uuid = Transaction._method(
+Transaction.modify = Transaction._method(
     "modify", "patch", "/transactions{/uuid}")
-Transaction._destroy_by_uuid = Transaction._method(
+Transaction.destroy = Transaction._method(
     "destroy", "delete", "/transactions{/uuid}")

--- a/chartmogul/api/transaction.py
+++ b/chartmogul/api/transaction.py
@@ -8,6 +8,7 @@ class Transaction(Resource):
     """
 
     _path = "/import/invoices{/uuid}/transactions"
+    _bool_query_params = ['handle_as_user_edit']
 
     class _Schema(Schema):
         uuid = fields.String()
@@ -30,27 +31,40 @@ class Transaction(Resource):
     _schema = _Schema(unknown=EXCLUDE)
 
     @classmethod
-    def retrieve_by_external_id(cls, config, **kwargs):
-        """GET /transactions with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "retrieve", "get", "/transactions", query_params=params)
+    def retrieve(cls, config, **kwargs):
+        if "data_source_uuid" in kwargs and "external_id" in kwargs:
+            params = _build_ext_id_params(kwargs)
+            return cls._request(config, "retrieve", "get", "/transactions",
+                                query_params=params)
+        return cls._retrieve_by_uuid(config, **kwargs)
 
     @classmethod
-    def update_by_external_id(cls, config, **kwargs):
-        """PATCH /transactions with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "modify", "patch", "/transactions",
-                            data=kwargs.get("data"), query_params=params)
+    def modify(cls, config, **kwargs):
+        if "data_source_uuid" in kwargs and "external_id" in kwargs:
+            params = _build_ext_id_params(kwargs)
+            return cls._request(config, "modify", "patch", "/transactions",
+                                data=kwargs.get("data"), query_params=params)
+        return cls._modify_by_uuid(config, **kwargs)
 
     @classmethod
-    def destroy_by_external_id(cls, config, **kwargs):
-        """DELETE /transactions with data_source_uuid + external_id query params."""
-        params = _build_ext_id_params(kwargs)
-        return cls._request(config, "destroy", "delete", "/transactions", query_params=params)
+    def destroy(cls, config, **kwargs):
+        if "data_source_uuid" in kwargs and "external_id" in kwargs:
+            params = _build_ext_id_params(kwargs)
+            return cls._request(config, "destroy", "delete", "/transactions",
+                                query_params=params)
+        return cls._destroy_by_uuid(config, **kwargs)
 
     @classmethod
-    def toggle_disabled_by_external_id(cls, config, **kwargs):
+    def toggle_disabled(cls, config, **kwargs):
         """PATCH /transactions/disabled_state with data_source_uuid + external_id query params."""
         params = _build_ext_id_params(kwargs)
         return cls._request(config, "modify", "patch", "/transactions/disabled_state",
                             data=kwargs.get("data"), query_params=params)
+
+
+Transaction._retrieve_by_uuid = Transaction._method(
+    "retrieve", "get", "/transactions{/uuid}")
+Transaction._modify_by_uuid = Transaction._method(
+    "modify", "patch", "/transactions{/uuid}")
+Transaction._destroy_by_uuid = Transaction._method(
+    "destroy", "delete", "/transactions{/uuid}")

--- a/chartmogul/api/transaction.py
+++ b/chartmogul/api/transaction.py
@@ -17,6 +17,7 @@ class Transaction(Resource):
         result = fields.String()
         amount_in_cents = fields.Int(allow_none=True)
         transaction_fees_in_cents = fields.Int(allow_none=True)
+        errors = fields.Dict(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):

--- a/chartmogul/api/transaction.py
+++ b/chartmogul/api/transaction.py
@@ -38,3 +38,5 @@ Transaction.modify = Transaction._method(
     "modify", "patch", "/transactions{/uuid}")
 Transaction.destroy = Transaction._method(
     "destroy", "delete", "/transactions{/uuid}")
+Transaction.disable = Transaction._method(
+    "disable", "patch", "/transactions{/uuid}/disabled_state")

--- a/chartmogul/api/transaction.py
+++ b/chartmogul/api/transaction.py
@@ -1,5 +1,5 @@
 from marshmallow import Schema, fields, post_load, EXCLUDE
-from ..resource import Resource
+from ..resource import Resource, _build_ext_id_params
 
 
 class Transaction(Resource):
@@ -17,10 +17,40 @@ class Transaction(Resource):
         result = fields.String()
         amount_in_cents = fields.Int(allow_none=True)
         transaction_fees_in_cents = fields.Int(allow_none=True)
+        transaction_fees_currency = fields.String(allow_none=True)
         errors = fields.Dict(allow_none=True)
+        disabled = fields.Boolean(allow_none=True)
+        disabled_at = fields.DateTime(allow_none=True)
+        disabled_by = fields.String(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):
             return Transaction(**data)
 
     _schema = _Schema(unknown=EXCLUDE)
+
+    @classmethod
+    def retrieve_by_external_id(cls, config, **kwargs):
+        """GET /transactions with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "retrieve", "get", "/transactions", query_params=params)
+
+    @classmethod
+    def update_by_external_id(cls, config, **kwargs):
+        """PATCH /transactions with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "modify", "patch", "/transactions",
+                            data=kwargs.get("data"), query_params=params)
+
+    @classmethod
+    def destroy_by_external_id(cls, config, **kwargs):
+        """DELETE /transactions with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "destroy", "delete", "/transactions", query_params=params)
+
+    @classmethod
+    def toggle_disabled_by_external_id(cls, config, **kwargs):
+        """PATCH /transactions/disabled_state with data_source_uuid + external_id query params."""
+        params = _build_ext_id_params(kwargs)
+        return cls._request(config, "modify", "patch", "/transactions/disabled_state",
+                            data=kwargs.get("data"), query_params=params)

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -174,7 +174,7 @@ class Resource(DataObject):
     def _validate_arguments(cls, method, kwargs):
         # This enforces user to pass argument, otherwise we could call
         # wrong URL.
-        if method in ["destroy", "cancel", "retrieve", "modify", "update"] and "uuid" not in kwargs:
+        if method in ["destroy", "cancel", "retrieve", "modify", "update", "disable"] and "uuid" not in kwargs:
             raise ArgumentMissingError("Please pass 'uuid' parameter")
         if method in ["create", "modify"] and "data" not in kwargs:
             raise ArgumentMissingError("Please pass 'data' parameter")

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -116,6 +116,18 @@ class Resource(DataObject):
             return cls._schema.load(jsonObj)
 
     @classmethod
+    def toggle_disabled(cls, config, **kwargs):
+        """PATCH /<resource>/disabled_state with data_source_uuid + external_id query params."""
+        ext_id_path = getattr(cls, '_ext_id_path', None)
+        if ext_id_path is None:
+            raise ConfigurationError(
+                "toggle_disabled requires _ext_id_path on the resource class")
+        params = _build_ext_id_params(kwargs)
+        return cls._request(
+            config, "modify", "patch", ext_id_path + "/disabled_state",
+            data=kwargs.get("data"), query_params=params)
+
+    @classmethod
     def _preProcessParams(cls, params):
         for key, replacement in ESCAPED_QUERY_KEYS.items():
             if key in params:
@@ -213,6 +225,16 @@ class Resource(DataObject):
             pathTemp = path  # due to Python closure
             if pathTemp is None:
                 pathTemp = cls._path
+
+            # Dispatch to external_id query-param path when supported.
+            ext_id_path = getattr(cls, '_ext_id_path', None)
+            if (ext_id_path is not None
+                    and "data_source_uuid" in kwargs
+                    and "external_id" in kwargs):
+                query_params = _build_ext_id_params(kwargs)
+                return cls._request(
+                    config, method, http_verb, ext_id_path,
+                    data=kwargs.get("data"), query_params=query_params)
 
             cls._validate_arguments(method, kwargs)
 

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -225,9 +225,19 @@ class Resource(DataObject):
                 suffix = ""
                 if pathTemp and "{/uuid}" in pathTemp:
                     suffix = pathTemp.split("{/uuid}", 1)[1]
-                return cls._request(
+                result = cls._request(
                     config, method, http_verb, ext_id_path + suffix,
                     data=kwargs.get("data"), query_params=query_params)
+                # For retrieve, unwrap the first item from the list response
+                # so the return type matches uuid-based retrieve.
+                if method == "retrieve" and hasattr(cls, '_root_key'):
+                    def _unwrap(many_result):
+                        items = getattr(many_result, cls._root_key, [])
+                        if items:
+                            return items[0]
+                        return None
+                    return result.then(_unwrap)
+                return result
 
             cls._validate_arguments(method, kwargs)
 

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -133,12 +133,12 @@ class Resource(DataObject):
         return params
 
     @classmethod
-    def _request(cls, config, method, http_verb, path, data=None, **kwargs):
+    def _request(cls, config, method, http_verb, path, data=None, query_params=None, **kwargs):
         if http_verb == "get":
-            params = cls._preProcessParams(kwargs)
+            params = query_params if query_params is not None else cls._preProcessParams(kwargs)
             data = None
         else:
-            params = None
+            params = query_params
             if data is not None:
                 data = dumps(data, default=json_serial)
 
@@ -243,3 +243,15 @@ def _add_method(cls, method, http_verb, path=None):
 
 for method, http_verb in MAPPINGS.items():
     _add_method(Resource, method, http_verb)
+
+
+def _build_ext_id_params(kwargs):
+    """Extract data_source_uuid, external_id, and optional handle_as_user_edit
+    from kwargs into a query params dict for external-id-based operations."""
+    params = {
+        "data_source_uuid": kwargs["data_source_uuid"],
+        "external_id": kwargs["external_id"],
+    }
+    if kwargs.get("handle_as_user_edit") is not None:
+        params["handle_as_user_edit"] = str(kwargs["handle_as_user_edit"]).lower()
+    return params

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -231,12 +231,10 @@ class Resource(DataObject):
                 # For retrieve, unwrap the first item from the list response
                 # so the return type matches uuid-based retrieve.
                 if method == "retrieve" and hasattr(cls, '_root_key'):
-                    def _unwrap(many_result):
-                        items = getattr(many_result, cls._root_key, [])
-                        if items:
-                            return items[0]
-                        return None
-                    return result.then(_unwrap)
+                    root_key = cls._root_key
+                    return result.then(
+                        lambda r: getattr(r, root_key, [None])[0]
+                        if getattr(r, root_key, []) else None)
                 return result
 
             cls._validate_arguments(method, kwargs)

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -116,18 +116,6 @@ class Resource(DataObject):
             return cls._schema.load(jsonObj)
 
     @classmethod
-    def toggle_disabled(cls, config, **kwargs):
-        """PATCH /<resource>/disabled_state with data_source_uuid + external_id query params."""
-        ext_id_path = getattr(cls, '_ext_id_path', None)
-        if ext_id_path is None:
-            raise ConfigurationError(
-                "toggle_disabled requires _ext_id_path on the resource class")
-        params = _build_ext_id_params(kwargs)
-        return cls._request(
-            config, "modify", "patch", ext_id_path + "/disabled_state",
-            data=kwargs.get("data"), query_params=params)
-
-    @classmethod
     def _preProcessParams(cls, params):
         for key, replacement in ESCAPED_QUERY_KEYS.items():
             if key in params:
@@ -232,8 +220,13 @@ class Resource(DataObject):
                     and "data_source_uuid" in kwargs
                     and "external_id" in kwargs):
                 query_params = _build_ext_id_params(kwargs)
+                # Preserve path suffix after {/uuid}, e.g.
+                # "/line_items{/uuid}/disabled_state" → "/line_items/disabled_state"
+                suffix = ""
+                if pathTemp and "{/uuid}" in pathTemp:
+                    suffix = pathTemp.split("{/uuid}", 1)[1]
                 return cls._request(
-                    config, method, http_verb, ext_id_path,
+                    config, method, http_verb, ext_id_path + suffix,
                     data=kwargs.get("data"), query_params=query_params)
 
             cls._validate_arguments(method, kwargs)

--- a/chartmogul/resource.py
+++ b/chartmogul/resource.py
@@ -135,10 +135,10 @@ class Resource(DataObject):
     @classmethod
     def _request(cls, config, method, http_verb, path, data=None, query_params=None, **kwargs):
         if http_verb == "get":
-            params = query_params if query_params is not None else cls._preProcessParams(kwargs)
+            params = cls._preProcessParams(query_params if query_params is not None else kwargs)
             data = None
         else:
-            params = query_params
+            params = cls._preProcessParams(query_params) if query_params is not None else None
             if data is not None:
                 data = dumps(data, default=json_serial)
 
@@ -253,5 +253,5 @@ def _build_ext_id_params(kwargs):
         "external_id": kwargs["external_id"],
     }
     if kwargs.get("handle_as_user_edit") is not None:
-        params["handle_as_user_edit"] = str(kwargs["handle_as_user_edit"]).lower()
+        params["handle_as_user_edit"] = kwargs["handle_as_user_edit"]
     return params

--- a/test/api/test_account.py
+++ b/test/api/test_account.py
@@ -12,6 +12,24 @@ jsonResponse = {
     "week_start_on": "sunday",
 }
 
+jsonResponseWithId = {
+    "id": "acct_a1b2c3d4",
+    "name": "Example Test Company",
+    "currency": "EUR",
+    "time_zone": "Europe/Berlin",
+    "week_start_on": "sunday",
+}
+
+jsonResponseWithInclude = {
+    "id": "acct_a1b2c3d4",
+    "name": "Example Test Company",
+    "currency": "EUR",
+    "time_zone": "Europe/Berlin",
+    "week_start_on": "sunday",
+    "churn_recognition": "immediate",
+    "churn_when_zero_mrr": "ignore",
+}
+
 
 class AccountTestCase(unittest.TestCase):
     """
@@ -35,3 +53,43 @@ class AccountTestCase(unittest.TestCase):
         self.assertEqual(account.currency, "EUR")
         self.assertEqual(account.time_zone, "Europe/Berlin")
         self.assertEqual(account.week_start_on, "sunday")
+
+    @requests_mock.mock()
+    def test_retrieve_with_id(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/account",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=jsonResponseWithId,
+        )
+
+        config = Config("token")
+        account = Account.retrieve(config).get()
+        self.assertTrue(isinstance(account, Account))
+        self.assertEqual(account.id, "acct_a1b2c3d4")
+
+    @requests_mock.mock()
+    def test_retrieve_with_include(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/account?include=churn_recognition,churn_when_zero_mrr",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=jsonResponseWithInclude,
+        )
+
+        config = Config("token")
+        account = Account.retrieve(
+            config,
+            include="churn_recognition,churn_when_zero_mrr"
+        ).get()
+        self.assertTrue(isinstance(account, Account))
+        self.assertEqual(account.id, "acct_a1b2c3d4")
+        self.assertEqual(account.churn_recognition, "immediate")
+        self.assertEqual(account.churn_when_zero_mrr, "ignore")
+        self.assertEqual(
+            mock_requests.last_request.qs,
+            {"include": ["churn_recognition,churn_when_zero_mrr"]},
+        )

--- a/test/api/test_account.py
+++ b/test/api/test_account.py
@@ -5,27 +5,20 @@ import requests_mock
 from chartmogul import Account, Config, APIError
 
 
-jsonResponse = {
+base_response = {
     "name": "Example Test Company",
     "currency": "EUR",
     "time_zone": "Europe/Berlin",
     "week_start_on": "sunday",
 }
 
-jsonResponseWithId = {
+response_with_id = {
+    **base_response,
     "id": "acct_a1b2c3d4",
-    "name": "Example Test Company",
-    "currency": "EUR",
-    "time_zone": "Europe/Berlin",
-    "week_start_on": "sunday",
 }
 
-jsonResponseWithInclude = {
-    "id": "acct_a1b2c3d4",
-    "name": "Example Test Company",
-    "currency": "EUR",
-    "time_zone": "Europe/Berlin",
-    "week_start_on": "sunday",
+response_with_include = {
+    **response_with_id,
     "churn_recognition": "immediate",
     "churn_when_zero_mrr": "ignore",
 }
@@ -43,7 +36,7 @@ class AccountTestCase(unittest.TestCase):
             "https://api.chartmogul.com/v1/account",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
-            json=jsonResponse,
+            json=base_response,
         )
 
         config = Config("token")  # is actually checked in mock
@@ -61,7 +54,7 @@ class AccountTestCase(unittest.TestCase):
             "https://api.chartmogul.com/v1/account",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
-            json=jsonResponseWithId,
+            json=response_with_id,
         )
 
         config = Config("token")
@@ -77,7 +70,7 @@ class AccountTestCase(unittest.TestCase):
             request_headers={"Authorization": "Basic dG9rZW46"},
             headers={"Content-Type": "application/json"},
             status_code=200,
-            json=jsonResponseWithInclude,
+            json=response_with_include,
         )
 
         config = Config("token")
@@ -102,7 +95,7 @@ class AccountTestCase(unittest.TestCase):
             "https://api.chartmogul.com/v1/account",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
-            json=jsonResponse,
+            json=base_response,
         )
 
         config = Config("token")
@@ -112,12 +105,8 @@ class AccountTestCase(unittest.TestCase):
 
     @requests_mock.mock()
     def test_retrieve_with_single_include(self, mock_requests):
-        singleIncludeResponse = {
-            "id": "acct_a1b2c3d4",
-            "name": "Example Test Company",
-            "currency": "EUR",
-            "time_zone": "Europe/Berlin",
-            "week_start_on": "sunday",
+        single_include_response = {
+            **response_with_id,
             "churn_recognition": "immediate",
         }
 
@@ -127,7 +116,7 @@ class AccountTestCase(unittest.TestCase):
             request_headers={"Authorization": "Basic dG9rZW46"},
             headers={"Content-Type": "application/json"},
             status_code=200,
-            json=singleIncludeResponse,
+            json=single_include_response,
         )
 
         config = Config("token")

--- a/test/api/test_account.py
+++ b/test/api/test_account.py
@@ -93,3 +93,52 @@ class AccountTestCase(unittest.TestCase):
             mock_requests.last_request.qs,
             {"include": ["churn_recognition,churn_when_zero_mrr"]},
         )
+
+    @requests_mock.mock()
+    def test_retrieve_without_id_field(self, mock_requests):
+        """Old API responses without id field should not break deserialization."""
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/account",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=jsonResponse,
+        )
+
+        config = Config("token")
+        account = Account.retrieve(config).get()
+        self.assertTrue(isinstance(account, Account))
+        self.assertFalse(hasattr(account, "id"))
+
+    @requests_mock.mock()
+    def test_retrieve_with_single_include(self, mock_requests):
+        singleIncludeResponse = {
+            "id": "acct_a1b2c3d4",
+            "name": "Example Test Company",
+            "currency": "EUR",
+            "time_zone": "Europe/Berlin",
+            "week_start_on": "sunday",
+            "churn_recognition": "immediate",
+        }
+
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/account?include=churn_recognition",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=singleIncludeResponse,
+        )
+
+        config = Config("token")
+        account = Account.retrieve(
+            config,
+            include="churn_recognition"
+        ).get()
+        self.assertTrue(isinstance(account, Account))
+        self.assertEqual(account.churn_recognition, "immediate")
+        self.assertFalse(hasattr(account, "churn_when_zero_mrr"))
+        self.assertEqual(
+            mock_requests.last_request.qs,
+            {"include": ["churn_recognition"]},
+        )

--- a/test/api/test_invoice.py
+++ b/test/api/test_invoice.py
@@ -621,3 +621,55 @@ class InvoiceTestCase(unittest.TestCase):
         self.assertEqual(qs["with_disabled"], ["true"])
         self.assertTrue(isinstance(result, Invoice._many))
         self.assertEqual(len(result.invoices), 1)
+
+    @requests_mock.mock()
+    def test_line_item_and_transaction_errors(self, mock_requests):
+        responseWithErrors = {
+            "uuid": "inv_test",
+            "external_id": "INV0001",
+            "date": "2015-11-01T00:00:00.000Z",
+            "due_date": "2015-11-15T00:00:00.000Z",
+            "currency": "USD",
+            "line_items": [
+                {
+                    "uuid": "li_test",
+                    "external_id": None,
+                    "type": "subscription",
+                    "prorated": False,
+                    "amount_in_cents": 5000,
+                    "quantity": 1,
+                    "discount_amount_in_cents": 0,
+                    "tax_amount_in_cents": 0,
+                    "transaction_fees_in_cents": 0,
+                    "errors": {"amount_in_cents": ["must be positive"]},
+                },
+            ],
+            "transactions": [
+                {
+                    "uuid": "tr_test",
+                    "external_id": None,
+                    "type": "payment",
+                    "date": "2015-11-05T00:04:03.000Z",
+                    "result": "successful",
+                    "errors": {"date": ["is in the future"]},
+                },
+            ],
+        }
+
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/invoices/inv_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=responseWithErrors,
+        )
+
+        config = Config("token")
+        result = Invoice.retrieve(config, uuid="inv_test").get()
+
+        self.assertTrue(isinstance(result, Invoice))
+        self.assertIsNotNone(result.line_items[0].errors)
+        self.assertEqual(result.line_items[0].errors["amount_in_cents"], ["must be positive"])
+        self.assertIsNotNone(result.transactions[0].errors)
+        self.assertEqual(result.transactions[0].errors["date"], ["is in the future"])

--- a/test/api/test_invoice.py
+++ b/test/api/test_invoice.py
@@ -722,3 +722,188 @@ class InvoiceTestCase(unittest.TestCase):
         self.assertEqual(mock_requests.call_count, 1, "expected call")
         self.assertTrue(isinstance(result, Invoice))
         self.assertTrue(result.disabled)
+
+    @requests_mock.mock()
+    def test_update_status_verifies_request_body(self, mock_requests):
+        updatedInvoice = dict(retrieveInvoiceExample)
+        updatedInvoice["disabled"] = False
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/invoices/inv_22910fc6-c931-48e7-ac12-90d2cb5f0059",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=updatedInvoice,
+        )
+
+        config = Config("token")
+        Invoice.update_status(
+            config,
+            uuid="inv_22910fc6-c931-48e7-ac12-90d2cb5f0059",
+            data={"disabled": False}
+        ).get()
+
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"disabled": False},
+        )
+
+    @requests_mock.mock()
+    def test_update_status_not_found(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/invoices/inv_nonexistent",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=404,
+            json={"error": "Invoice not found"},
+        )
+
+        config = Config("token")
+        with self.assertRaises(APIError):
+            Invoice.update_status(
+                config,
+                uuid="inv_nonexistent",
+                data={"disabled": False}
+            ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+
+    @requests_mock.mock()
+    def test_disable_no_request_body(self, mock_requests):
+        disabledInvoice = dict(retrieveInvoiceExample)
+        disabledInvoice["disabled"] = True
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/invoices/inv_22910fc6-c931-48e7-ac12-90d2cb5f0059/disable",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=disabledInvoice,
+        )
+
+        config = Config("token")
+        Invoice.disable(
+            config,
+            uuid="inv_22910fc6-c931-48e7-ac12-90d2cb5f0059",
+        ).get()
+
+        self.assertIsNone(mock_requests.last_request.body)
+
+    @requests_mock.mock()
+    def test_disable_not_found(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/invoices/inv_nonexistent/disable",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=404,
+            json={"error": "Invoice not found"},
+        )
+
+        config = Config("token")
+        with self.assertRaises(APIError):
+            Invoice.disable(config, uuid="inv_nonexistent").get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+
+    @requests_mock.mock()
+    def test_line_item_errors_none(self, mock_requests):
+        responseWithNoneErrors = {
+            "uuid": "inv_test",
+            "external_id": "INV0001",
+            "date": "2015-11-01T00:00:00.000Z",
+            "due_date": "2015-11-15T00:00:00.000Z",
+            "currency": "USD",
+            "line_items": [
+                {
+                    "uuid": "li_test",
+                    "external_id": None,
+                    "type": "subscription",
+                    "prorated": False,
+                    "amount_in_cents": 5000,
+                    "quantity": 1,
+                    "discount_amount_in_cents": 0,
+                    "tax_amount_in_cents": 0,
+                    "transaction_fees_in_cents": 0,
+                    "errors": None,
+                },
+            ],
+            "transactions": [
+                {
+                    "uuid": "tr_test",
+                    "external_id": None,
+                    "type": "payment",
+                    "date": "2015-11-05T00:04:03.000Z",
+                    "result": "successful",
+                    "errors": None,
+                },
+            ],
+        }
+
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/invoices/inv_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=responseWithNoneErrors,
+        )
+
+        config = Config("token")
+        result = Invoice.retrieve(config, uuid="inv_test").get()
+
+        self.assertTrue(isinstance(result, Invoice))
+        self.assertIsNone(result.line_items[0].errors)
+        self.assertIsNone(result.transactions[0].errors)
+
+    @requests_mock.mock()
+    def test_line_item_errors_absent(self, mock_requests):
+        responseNoErrors = {
+            "uuid": "inv_test",
+            "external_id": "INV0001",
+            "date": "2015-11-01T00:00:00.000Z",
+            "due_date": "2015-11-15T00:00:00.000Z",
+            "currency": "USD",
+            "line_items": [
+                {
+                    "uuid": "li_test",
+                    "external_id": None,
+                    "type": "subscription",
+                    "prorated": False,
+                    "amount_in_cents": 5000,
+                    "quantity": 1,
+                    "discount_amount_in_cents": 0,
+                    "tax_amount_in_cents": 0,
+                    "transaction_fees_in_cents": 0,
+                },
+            ],
+            "transactions": [
+                {
+                    "uuid": "tr_test",
+                    "external_id": None,
+                    "type": "payment",
+                    "date": "2015-11-05T00:04:03.000Z",
+                    "result": "successful",
+                },
+            ],
+        }
+
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/invoices/inv_test_no_errors",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=responseNoErrors,
+        )
+
+        config = Config("token")
+        result = Invoice.retrieve(config, uuid="inv_test_no_errors").get()
+
+        self.assertTrue(isinstance(result, Invoice))
+        # When errors field is absent from response, the attribute should not be set
+        self.assertFalse(hasattr(result.line_items[0], "errors"))
+        self.assertFalse(hasattr(result.transactions[0], "errors"))

--- a/test/api/test_invoice.py
+++ b/test/api/test_invoice.py
@@ -623,39 +623,45 @@ class InvoiceTestCase(unittest.TestCase):
         self.assertTrue(isinstance(result, Invoice._many))
         self.assertEqual(len(result.invoices), 1)
 
-    @requests_mock.mock()
-    def test_line_item_and_transaction_errors(self, mock_requests):
-        responseWithErrors = {
+    def _make_errors_response(self, li_errors=None, tx_errors=None, include_errors=True):
+        """Build a minimal invoice response with configurable errors fields."""
+        li = {
+            "uuid": "li_test",
+            "external_id": None,
+            "type": "subscription",
+            "prorated": False,
+            "amount_in_cents": 5000,
+            "quantity": 1,
+            "discount_amount_in_cents": 0,
+            "tax_amount_in_cents": 0,
+            "transaction_fees_in_cents": 0,
+        }
+        tx = {
+            "uuid": "tr_test",
+            "external_id": None,
+            "type": "payment",
+            "date": "2015-11-05T00:04:03.000Z",
+            "result": "successful",
+        }
+        if include_errors:
+            li["errors"] = li_errors
+            tx["errors"] = tx_errors
+        return {
             "uuid": "inv_test",
             "external_id": "INV0001",
             "date": "2015-11-01T00:00:00.000Z",
             "due_date": "2015-11-15T00:00:00.000Z",
             "currency": "USD",
-            "line_items": [
-                {
-                    "uuid": "li_test",
-                    "external_id": None,
-                    "type": "subscription",
-                    "prorated": False,
-                    "amount_in_cents": 5000,
-                    "quantity": 1,
-                    "discount_amount_in_cents": 0,
-                    "tax_amount_in_cents": 0,
-                    "transaction_fees_in_cents": 0,
-                    "errors": {"amount_in_cents": ["must be positive"]},
-                },
-            ],
-            "transactions": [
-                {
-                    "uuid": "tr_test",
-                    "external_id": None,
-                    "type": "payment",
-                    "date": "2015-11-05T00:04:03.000Z",
-                    "result": "successful",
-                    "errors": {"date": ["is in the future"]},
-                },
-            ],
+            "line_items": [li],
+            "transactions": [tx],
         }
+
+    @requests_mock.mock()
+    def test_line_item_and_transaction_errors(self, mock_requests):
+        response = self._make_errors_response(
+            li_errors={"amount_in_cents": ["must be positive"]},
+            tx_errors={"date": ["is in the future"]},
+        )
 
         mock_requests.register_uri(
             "GET",
@@ -663,7 +669,7 @@ class InvoiceTestCase(unittest.TestCase):
             request_headers={"Authorization": "Basic dG9rZW46"},
             headers={"Content-Type": "application/json"},
             status_code=200,
-            json=responseWithErrors,
+            json=response,
         )
 
         config = Config("token")
@@ -812,37 +818,7 @@ class InvoiceTestCase(unittest.TestCase):
 
     @requests_mock.mock()
     def test_line_item_errors_none(self, mock_requests):
-        responseWithNoneErrors = {
-            "uuid": "inv_test",
-            "external_id": "INV0001",
-            "date": "2015-11-01T00:00:00.000Z",
-            "due_date": "2015-11-15T00:00:00.000Z",
-            "currency": "USD",
-            "line_items": [
-                {
-                    "uuid": "li_test",
-                    "external_id": None,
-                    "type": "subscription",
-                    "prorated": False,
-                    "amount_in_cents": 5000,
-                    "quantity": 1,
-                    "discount_amount_in_cents": 0,
-                    "tax_amount_in_cents": 0,
-                    "transaction_fees_in_cents": 0,
-                    "errors": None,
-                },
-            ],
-            "transactions": [
-                {
-                    "uuid": "tr_test",
-                    "external_id": None,
-                    "type": "payment",
-                    "date": "2015-11-05T00:04:03.000Z",
-                    "result": "successful",
-                    "errors": None,
-                },
-            ],
-        }
+        response = self._make_errors_response(li_errors=None, tx_errors=None)
 
         mock_requests.register_uri(
             "GET",
@@ -850,7 +826,7 @@ class InvoiceTestCase(unittest.TestCase):
             request_headers={"Authorization": "Basic dG9rZW46"},
             headers={"Content-Type": "application/json"},
             status_code=200,
-            json=responseWithNoneErrors,
+            json=response,
         )
 
         config = Config("token")
@@ -862,35 +838,7 @@ class InvoiceTestCase(unittest.TestCase):
 
     @requests_mock.mock()
     def test_line_item_errors_absent(self, mock_requests):
-        responseNoErrors = {
-            "uuid": "inv_test",
-            "external_id": "INV0001",
-            "date": "2015-11-01T00:00:00.000Z",
-            "due_date": "2015-11-15T00:00:00.000Z",
-            "currency": "USD",
-            "line_items": [
-                {
-                    "uuid": "li_test",
-                    "external_id": None,
-                    "type": "subscription",
-                    "prorated": False,
-                    "amount_in_cents": 5000,
-                    "quantity": 1,
-                    "discount_amount_in_cents": 0,
-                    "tax_amount_in_cents": 0,
-                    "transaction_fees_in_cents": 0,
-                },
-            ],
-            "transactions": [
-                {
-                    "uuid": "tr_test",
-                    "external_id": None,
-                    "type": "payment",
-                    "date": "2015-11-05T00:04:03.000Z",
-                    "result": "successful",
-                },
-            ],
-        }
+        response = self._make_errors_response(include_errors=False)
 
         mock_requests.register_uri(
             "GET",
@@ -898,7 +846,7 @@ class InvoiceTestCase(unittest.TestCase):
             request_headers={"Authorization": "Basic dG9rZW46"},
             headers={"Content-Type": "application/json"},
             status_code=200,
-            json=responseNoErrors,
+            json=response,
         )
 
         config = Config("token")

--- a/test/api/test_invoice.py
+++ b/test/api/test_invoice.py
@@ -8,6 +8,7 @@ from requests.exceptions import HTTPError
 
 from chartmogul import Config
 from chartmogul import APIError
+from chartmogul import ArgumentMissingError
 from chartmogul import Invoice
 
 
@@ -907,3 +908,8 @@ class InvoiceTestCase(unittest.TestCase):
         # When errors field is absent from response, the attribute should not be set
         self.assertFalse(hasattr(result.line_items[0], "errors"))
         self.assertFalse(hasattr(result.transactions[0], "errors"))
+
+    def test_disable_missing_uuid_raises(self):
+        config = Config("token")
+        with self.assertRaises(ArgumentMissingError):
+            Invoice.disable(config)

--- a/test/api/test_invoice.py
+++ b/test/api/test_invoice.py
@@ -673,3 +673,52 @@ class InvoiceTestCase(unittest.TestCase):
         self.assertEqual(result.line_items[0].errors["amount_in_cents"], ["must be positive"])
         self.assertIsNotNone(result.transactions[0].errors)
         self.assertEqual(result.transactions[0].errors["date"], ["is in the future"])
+
+    @requests_mock.mock()
+    def test_update_status(self, mock_requests):
+        updatedInvoice = dict(retrieveInvoiceExample)
+        updatedInvoice["disabled"] = False
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/invoices/inv_22910fc6-c931-48e7-ac12-90d2cb5f0059",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=updatedInvoice,
+        )
+
+        config = Config("token")
+        result = Invoice.update_status(
+            config,
+            uuid="inv_22910fc6-c931-48e7-ac12-90d2cb5f0059",
+            data={"disabled": False}
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertTrue(isinstance(result, Invoice))
+        self.assertEqual(result.uuid, "inv_22910fc6-c931-48e7-ac12-90d2cb5f0059")
+
+    @requests_mock.mock()
+    def test_disable(self, mock_requests):
+        disabledInvoice = dict(retrieveInvoiceExample)
+        disabledInvoice["disabled"] = True
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/invoices/inv_22910fc6-c931-48e7-ac12-90d2cb5f0059/disable",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=disabledInvoice,
+        )
+
+        config = Config("token")
+        result = Invoice.disable(
+            config,
+            uuid="inv_22910fc6-c931-48e7-ac12-90d2cb5f0059",
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertTrue(isinstance(result, Invoice))
+        self.assertTrue(result.disabled)

--- a/test/api/test_invoice.py
+++ b/test/api/test_invoice.py
@@ -713,7 +713,7 @@ class InvoiceTestCase(unittest.TestCase):
 
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/invoices/inv_22910fc6-c931-48e7-ac12-90d2cb5f0059/disable",
+            "https://api.chartmogul.com/v1/invoices/inv_22910fc6-c931-48e7-ac12-90d2cb5f0059/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             headers={"Content-Type": "application/json"},
             status_code=200,
@@ -784,7 +784,7 @@ class InvoiceTestCase(unittest.TestCase):
 
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/invoices/inv_22910fc6-c931-48e7-ac12-90d2cb5f0059/disable",
+            "https://api.chartmogul.com/v1/invoices/inv_22910fc6-c931-48e7-ac12-90d2cb5f0059/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             headers={"Content-Type": "application/json"},
             status_code=200,
@@ -803,7 +803,7 @@ class InvoiceTestCase(unittest.TestCase):
     def test_disable_not_found(self, mock_requests):
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/invoices/inv_nonexistent/disable",
+            "https://api.chartmogul.com/v1/invoices/inv_nonexistent/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             headers={"Content-Type": "application/json"},
             status_code=404,

--- a/test/api/test_invoice_external_id.py
+++ b/test/api/test_invoice_external_id.py
@@ -36,7 +36,7 @@ single_invoice_response = {
 class InvoiceExternalIdTestCase(unittest.TestCase):
 
     @requests_mock.mock()
-    def test_retrieve_by_external_id(self, mock_requests):
+    def test_retrieve_with_external_id(self, mock_requests):
         mock_requests.register_uri(
             "GET",
             "https://api.chartmogul.com/v1/invoices"
@@ -47,7 +47,7 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = Invoice.retrieve_by_external_id(
+        result = Invoice.retrieve(
             config, data_source_uuid="ds_123", external_id="inv_ext_1"
         ).get()
 
@@ -56,7 +56,23 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         self.assertIn("external_id", mock_requests.last_request.qs)
 
     @requests_mock.mock()
-    def test_update_by_external_id(self, mock_requests):
+    def test_retrieve_with_uuid_still_works(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/invoices/inv_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=single_invoice_response,
+        )
+
+        config = Config("token")
+        result = Invoice.retrieve(config, uuid="inv_test").get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(isinstance(result, Invoice))
+
+    @requests_mock.mock()
+    def test_update_status_with_external_id(self, mock_requests):
         mock_requests.register_uri(
             "PATCH",
             "https://api.chartmogul.com/v1/invoices"
@@ -67,7 +83,7 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = Invoice.update_by_external_id(
+        result = Invoice.update_status(
             config,
             data_source_uuid="ds_123",
             external_id="inv_ext_1",
@@ -79,7 +95,7 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         self.assertEqual(mock_requests.last_request.json(), {"currency": "EUR"})
 
     @requests_mock.mock()
-    def test_update_by_external_id_with_handle_as_user_edit(self, mock_requests):
+    def test_update_status_with_handle_as_user_edit(self, mock_requests):
         mock_requests.register_uri(
             "PATCH",
             "https://api.chartmogul.com/v1/invoices"
@@ -90,7 +106,7 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = Invoice.update_by_external_id(
+        Invoice.update_status(
             config,
             data_source_uuid="ds_123",
             external_id="inv_ext_1",
@@ -104,7 +120,7 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         )
 
     @requests_mock.mock()
-    def test_destroy_by_external_id(self, mock_requests):
+    def test_destroy_with_external_id(self, mock_requests):
         mock_requests.register_uri(
             "DELETE",
             "https://api.chartmogul.com/v1/invoices"
@@ -114,7 +130,7 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = Invoice.destroy_by_external_id(
+        result = Invoice.destroy(
             config, data_source_uuid="ds_123", external_id="inv_ext_1"
         ).get()
 
@@ -123,7 +139,7 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         self.assertTrue(result is None)
 
     @requests_mock.mock()
-    def test_toggle_disabled_by_external_id(self, mock_requests):
+    def test_toggle_disabled(self, mock_requests):
         mock_requests.register_uri(
             "PATCH",
             "https://api.chartmogul.com/v1/invoices/disabled_state"
@@ -134,7 +150,7 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = Invoice.toggle_disabled_by_external_id(
+        result = Invoice.toggle_disabled(
             config,
             data_source_uuid="ds_123",
             external_id="inv_ext_1",
@@ -146,7 +162,7 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         self.assertTrue(isinstance(result, Invoice))
 
     @requests_mock.mock()
-    def test_destroy_by_external_id_not_found(self, mock_requests):
+    def test_destroy_with_external_id_not_found(self, mock_requests):
         mock_requests.register_uri(
             "DELETE",
             "https://api.chartmogul.com/v1/invoices"
@@ -159,6 +175,6 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
 
         config = Config("token")
         with self.assertRaises(APIError):
-            Invoice.destroy_by_external_id(
+            Invoice.destroy(
                 config, data_source_uuid="ds_123", external_id="inv_bad"
             ).get()

--- a/test/api/test_invoice_external_id.py
+++ b/test/api/test_invoice_external_id.py
@@ -1,0 +1,164 @@
+import unittest
+
+import requests_mock
+
+from chartmogul import Invoice, Config, APIError
+
+
+invoice_response = {
+    "invoices": [
+        {
+            "uuid": "inv_test",
+            "external_id": "inv_ext_1",
+            "date": "2025-11-01T00:00:00.000Z",
+            "due_date": "2025-11-15T00:00:00.000Z",
+            "currency": "USD",
+            "line_items": [],
+            "transactions": [],
+        }
+    ],
+    "cursor": None,
+    "has_more": False,
+}
+
+single_invoice_response = {
+    "uuid": "inv_test",
+    "external_id": "inv_ext_1",
+    "date": "2025-11-01T00:00:00.000Z",
+    "due_date": "2025-11-15T00:00:00.000Z",
+    "currency": "USD",
+    "disabled": True,
+    "line_items": [],
+    "transactions": [],
+}
+
+
+class InvoiceExternalIdTestCase(unittest.TestCase):
+
+    @requests_mock.mock()
+    def test_retrieve_by_external_id(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/invoices"
+            "?data_source_uuid=ds_123&external_id=inv_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=invoice_response,
+        )
+
+        config = Config("token")
+        result = Invoice.retrieve_by_external_id(
+            config, data_source_uuid="ds_123", external_id="inv_ext_1"
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertIn("data_source_uuid", mock_requests.last_request.qs)
+        self.assertIn("external_id", mock_requests.last_request.qs)
+
+    @requests_mock.mock()
+    def test_update_by_external_id(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/invoices"
+            "?data_source_uuid=ds_123&external_id=inv_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=single_invoice_response,
+        )
+
+        config = Config("token")
+        result = Invoice.update_by_external_id(
+            config,
+            data_source_uuid="ds_123",
+            external_id="inv_ext_1",
+            data={"currency": "EUR"},
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertIn("data_source_uuid", mock_requests.last_request.qs)
+        self.assertEqual(mock_requests.last_request.json(), {"currency": "EUR"})
+
+    @requests_mock.mock()
+    def test_update_by_external_id_with_handle_as_user_edit(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/invoices"
+            "?data_source_uuid=ds_123&external_id=inv_ext_1&handle_as_user_edit=true",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=single_invoice_response,
+        )
+
+        config = Config("token")
+        result = Invoice.update_by_external_id(
+            config,
+            data_source_uuid="ds_123",
+            external_id="inv_ext_1",
+            handle_as_user_edit=True,
+            data={"currency": "EUR"},
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertEqual(
+            mock_requests.last_request.qs["handle_as_user_edit"], ["true"]
+        )
+
+    @requests_mock.mock()
+    def test_destroy_by_external_id(self, mock_requests):
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/invoices"
+            "?data_source_uuid=ds_123&external_id=inv_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = Invoice.destroy_by_external_id(
+            config, data_source_uuid="ds_123", external_id="inv_ext_1"
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertIn("data_source_uuid", mock_requests.last_request.qs)
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
+    def test_toggle_disabled_by_external_id(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/invoices/disabled_state"
+            "?data_source_uuid=ds_123&external_id=inv_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=single_invoice_response,
+        )
+
+        config = Config("token")
+        result = Invoice.toggle_disabled_by_external_id(
+            config,
+            data_source_uuid="ds_123",
+            external_id="inv_ext_1",
+            data={"disabled": True},
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertEqual(mock_requests.last_request.json(), {"disabled": True})
+        self.assertTrue(isinstance(result, Invoice))
+
+    @requests_mock.mock()
+    def test_destroy_by_external_id_not_found(self, mock_requests):
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/invoices"
+            "?data_source_uuid=ds_123&external_id=inv_bad",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=404,
+            json={"error": "Invoice not found"},
+        )
+
+        config = Config("token")
+        with self.assertRaises(APIError):
+            Invoice.destroy_by_external_id(
+                config, data_source_uuid="ds_123", external_id="inv_bad"
+            ).get()

--- a/test/api/test_invoice_external_id.py
+++ b/test/api/test_invoice_external_id.py
@@ -54,6 +54,9 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         self.assertEqual(mock_requests.call_count, 1)
         self.assertIn("data_source_uuid", mock_requests.last_request.qs)
         self.assertIn("external_id", mock_requests.last_request.qs)
+        # Returns a single Invoice, same as uuid-based retrieve
+        self.assertTrue(isinstance(result, Invoice))
+        self.assertEqual(result.uuid, "inv_test")
 
     @requests_mock.mock()
     def test_retrieve_with_uuid_still_works(self, mock_requests):
@@ -160,6 +163,24 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         self.assertEqual(mock_requests.call_count, 1)
         self.assertEqual(mock_requests.last_request.json(), {"disabled": True})
         self.assertTrue(isinstance(result, Invoice))
+
+    @requests_mock.mock()
+    def test_retrieve_with_external_id_empty_returns_none(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/invoices"
+            "?data_source_uuid=ds_123&external_id=inv_bad",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json={"invoices": [], "cursor": None, "has_more": False},
+        )
+
+        config = Config("token")
+        result = Invoice.retrieve(
+            config, data_source_uuid="ds_123", external_id="inv_bad"
+        ).get()
+
+        self.assertIsNone(result)
 
     @requests_mock.mock()
     def test_destroy_with_external_id_not_found(self, mock_requests):

--- a/test/api/test_invoice_external_id.py
+++ b/test/api/test_invoice_external_id.py
@@ -139,7 +139,7 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         self.assertTrue(result is None)
 
     @requests_mock.mock()
-    def test_toggle_disabled(self, mock_requests):
+    def test_disable(self, mock_requests):
         mock_requests.register_uri(
             "PATCH",
             "https://api.chartmogul.com/v1/invoices/disabled_state"
@@ -150,7 +150,7 @@ class InvoiceExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = Invoice.toggle_disabled(
+        result = Invoice.disable(
             config,
             data_source_uuid="ds_123",
             external_id="inv_ext_1",

--- a/test/api/test_line_item.py
+++ b/test/api/test_line_item.py
@@ -1,0 +1,158 @@
+import unittest
+
+import requests_mock
+
+from chartmogul import LineItem, Config, APIError
+
+
+line_item_response = {
+    "uuid": "li_test",
+    "external_id": "li_ext_1",
+    "type": "subscription",
+    "amount_in_cents": 5000,
+    "quantity": 1,
+    "discount_amount_in_cents": 0,
+    "tax_amount_in_cents": 0,
+    "transaction_fees_in_cents": 0,
+    "prorated": False,
+    "disabled": False,
+}
+
+
+class LineItemExternalIdTestCase(unittest.TestCase):
+
+    @requests_mock.mock()
+    def test_retrieve_by_external_id(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/line_items"
+            "?data_source_uuid=ds_123&external_id=li_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=line_item_response,
+        )
+
+        config = Config("token")
+        result = LineItem.retrieve_by_external_id(
+            config, data_source_uuid="ds_123", external_id="li_ext_1"
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertIn("data_source_uuid", mock_requests.last_request.qs)
+        self.assertIn("external_id", mock_requests.last_request.qs)
+        self.assertTrue(isinstance(result, LineItem))
+        self.assertEqual(result.uuid, "li_test")
+
+    @requests_mock.mock()
+    def test_update_by_external_id(self, mock_requests):
+        updated = dict(line_item_response)
+        updated["amount_in_cents"] = 10000
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/line_items"
+            "?data_source_uuid=ds_123&external_id=li_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=updated,
+        )
+
+        config = Config("token")
+        result = LineItem.update_by_external_id(
+            config,
+            data_source_uuid="ds_123",
+            external_id="li_ext_1",
+            data={"amount_in_cents": 10000},
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertEqual(mock_requests.last_request.json(), {"amount_in_cents": 10000})
+        self.assertTrue(isinstance(result, LineItem))
+        self.assertEqual(result.amount_in_cents, 10000)
+
+    @requests_mock.mock()
+    def test_update_by_external_id_with_handle_as_user_edit(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/line_items"
+            "?data_source_uuid=ds_123&external_id=li_ext_1&handle_as_user_edit=true",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=line_item_response,
+        )
+
+        config = Config("token")
+        LineItem.update_by_external_id(
+            config,
+            data_source_uuid="ds_123",
+            external_id="li_ext_1",
+            handle_as_user_edit=True,
+            data={"amount_in_cents": 5000},
+        ).get()
+
+        self.assertEqual(
+            mock_requests.last_request.qs["handle_as_user_edit"], ["true"]
+        )
+
+    @requests_mock.mock()
+    def test_destroy_by_external_id(self, mock_requests):
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/line_items"
+            "?data_source_uuid=ds_123&external_id=li_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = LineItem.destroy_by_external_id(
+            config, data_source_uuid="ds_123", external_id="li_ext_1"
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
+    def test_toggle_disabled_by_external_id(self, mock_requests):
+        disabled = dict(line_item_response)
+        disabled["disabled"] = True
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/line_items/disabled_state"
+            "?data_source_uuid=ds_123&external_id=li_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=disabled,
+        )
+
+        config = Config("token")
+        result = LineItem.toggle_disabled_by_external_id(
+            config,
+            data_source_uuid="ds_123",
+            external_id="li_ext_1",
+            data={"disabled": True},
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertEqual(mock_requests.last_request.json(), {"disabled": True})
+        self.assertTrue(isinstance(result, LineItem))
+        self.assertTrue(result.disabled)
+
+    @requests_mock.mock()
+    def test_retrieve_by_external_id_not_found(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/line_items"
+            "?data_source_uuid=ds_123&external_id=li_bad",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=404,
+            json={"error": "Line item not found"},
+        )
+
+        config = Config("token")
+        with self.assertRaises(APIError):
+            LineItem.retrieve_by_external_id(
+                config, data_source_uuid="ds_123", external_id="li_bad"
+            ).get()

--- a/test/api/test_line_item.py
+++ b/test/api/test_line_item.py
@@ -113,7 +113,7 @@ class LineItemTestCase(unittest.TestCase):
         self.assertTrue(result is None)
 
     @requests_mock.mock()
-    def test_toggle_disabled(self, mock_requests):
+    def test_disable(self, mock_requests):
         disabled = dict(line_item_response)
         disabled["disabled"] = True
 
@@ -127,7 +127,7 @@ class LineItemTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = LineItem.toggle_disabled(
+        result = LineItem.disable(
             config,
             data_source_uuid="ds_123",
             external_id="li_ext_1",

--- a/test/api/test_line_item.py
+++ b/test/api/test_line_item.py
@@ -194,6 +194,48 @@ class LineItemTestCase(unittest.TestCase):
         self.assertTrue(result is None)
 
     @requests_mock.mock()
+    def test_create(self, mock_requests):
+        mock_requests.register_uri(
+            "POST",
+            "https://api.chartmogul.com/v1/import/invoices/inv_123/line_items",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=line_item_response,
+        )
+
+        config = Config("token")
+        result = LineItem.create(
+            config,
+            uuid="inv_123",
+            data={"type": "subscription", "amount_in_cents": 5000},
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(isinstance(result, LineItem))
+
+    @requests_mock.mock()
+    def test_disable_by_uuid(self, mock_requests):
+        disabled = dict(line_item_response)
+        disabled["disabled"] = True
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/line_items/li_test/disabled_state",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=disabled,
+        )
+
+        config = Config("token")
+        result = LineItem.disable(
+            config, uuid="li_test", data={"disabled": True}
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(isinstance(result, LineItem))
+        self.assertTrue(result.disabled)
+
+    @requests_mock.mock()
     def test_retrieve_not_found(self, mock_requests):
         mock_requests.register_uri(
             "GET",

--- a/test/api/test_line_item.py
+++ b/test/api/test_line_item.py
@@ -19,10 +19,10 @@ line_item_response = {
 }
 
 
-class LineItemExternalIdTestCase(unittest.TestCase):
+class LineItemTestCase(unittest.TestCase):
 
     @requests_mock.mock()
-    def test_retrieve_by_external_id(self, mock_requests):
+    def test_retrieve(self, mock_requests):
         mock_requests.register_uri(
             "GET",
             "https://api.chartmogul.com/v1/line_items"
@@ -33,7 +33,7 @@ class LineItemExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = LineItem.retrieve_by_external_id(
+        result = LineItem.retrieve(
             config, data_source_uuid="ds_123", external_id="li_ext_1"
         ).get()
 
@@ -44,7 +44,7 @@ class LineItemExternalIdTestCase(unittest.TestCase):
         self.assertEqual(result.uuid, "li_test")
 
     @requests_mock.mock()
-    def test_update_by_external_id(self, mock_requests):
+    def test_modify(self, mock_requests):
         updated = dict(line_item_response)
         updated["amount_in_cents"] = 10000
 
@@ -58,7 +58,7 @@ class LineItemExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = LineItem.update_by_external_id(
+        result = LineItem.modify(
             config,
             data_source_uuid="ds_123",
             external_id="li_ext_1",
@@ -71,7 +71,7 @@ class LineItemExternalIdTestCase(unittest.TestCase):
         self.assertEqual(result.amount_in_cents, 10000)
 
     @requests_mock.mock()
-    def test_update_by_external_id_with_handle_as_user_edit(self, mock_requests):
+    def test_modify_with_handle_as_user_edit(self, mock_requests):
         mock_requests.register_uri(
             "PATCH",
             "https://api.chartmogul.com/v1/line_items"
@@ -82,7 +82,7 @@ class LineItemExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        LineItem.update_by_external_id(
+        LineItem.modify(
             config,
             data_source_uuid="ds_123",
             external_id="li_ext_1",
@@ -95,7 +95,7 @@ class LineItemExternalIdTestCase(unittest.TestCase):
         )
 
     @requests_mock.mock()
-    def test_destroy_by_external_id(self, mock_requests):
+    def test_destroy(self, mock_requests):
         mock_requests.register_uri(
             "DELETE",
             "https://api.chartmogul.com/v1/line_items"
@@ -105,7 +105,7 @@ class LineItemExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = LineItem.destroy_by_external_id(
+        result = LineItem.destroy(
             config, data_source_uuid="ds_123", external_id="li_ext_1"
         ).get()
 
@@ -113,7 +113,7 @@ class LineItemExternalIdTestCase(unittest.TestCase):
         self.assertTrue(result is None)
 
     @requests_mock.mock()
-    def test_toggle_disabled_by_external_id(self, mock_requests):
+    def test_toggle_disabled(self, mock_requests):
         disabled = dict(line_item_response)
         disabled["disabled"] = True
 
@@ -127,7 +127,7 @@ class LineItemExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = LineItem.toggle_disabled_by_external_id(
+        result = LineItem.toggle_disabled(
             config,
             data_source_uuid="ds_123",
             external_id="li_ext_1",
@@ -140,7 +140,7 @@ class LineItemExternalIdTestCase(unittest.TestCase):
         self.assertTrue(result.disabled)
 
     @requests_mock.mock()
-    def test_retrieve_by_external_id_not_found(self, mock_requests):
+    def test_retrieve_not_found(self, mock_requests):
         mock_requests.register_uri(
             "GET",
             "https://api.chartmogul.com/v1/line_items"
@@ -153,6 +153,6 @@ class LineItemExternalIdTestCase(unittest.TestCase):
 
         config = Config("token")
         with self.assertRaises(APIError):
-            LineItem.retrieve_by_external_id(
+            LineItem.retrieve(
                 config, data_source_uuid="ds_123", external_id="li_bad"
             ).get()

--- a/test/api/test_line_item.py
+++ b/test/api/test_line_item.py
@@ -140,6 +140,60 @@ class LineItemTestCase(unittest.TestCase):
         self.assertTrue(result.disabled)
 
     @requests_mock.mock()
+    def test_retrieve_by_uuid(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/line_items/li_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=line_item_response,
+        )
+
+        config = Config("token")
+        result = LineItem.retrieve(config, uuid="li_test").get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(isinstance(result, LineItem))
+        self.assertEqual(result.uuid, "li_test")
+
+    @requests_mock.mock()
+    def test_modify_by_uuid(self, mock_requests):
+        updated = dict(line_item_response)
+        updated["amount_in_cents"] = 10000
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/line_items/li_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=updated,
+        )
+
+        config = Config("token")
+        result = LineItem.modify(
+            config, uuid="li_test", data={"amount_in_cents": 10000}
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(isinstance(result, LineItem))
+        self.assertEqual(result.amount_in_cents, 10000)
+
+    @requests_mock.mock()
+    def test_destroy_by_uuid(self, mock_requests):
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/line_items/li_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = LineItem.destroy(config, uuid="li_test").get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
     def test_retrieve_not_found(self, mock_requests):
         mock_requests.register_uri(
             "GET",

--- a/test/api/test_subscription_event.py
+++ b/test/api/test_subscription_event.py
@@ -304,6 +304,166 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertFalse(body["subscription_event"]["disabled"])
 
     @requests_mock.mock()
+    def test_destroy_flat_with_external_id_and_ds_uuid(self, mock_requests):
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = SubscriptionEvent.destroy(
+            config,
+            data={
+                "external_id": "evnt_026",
+                "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+            }
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {
+                "subscription_event": {
+                    "external_id": "evnt_026",
+                    "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+                }
+            },
+        )
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
+    def test_modify_flat_with_external_id_and_ds_uuid(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.modify(
+            config,
+            data={
+                "external_id": "evnt_026",
+                "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+                "amount_in_cents": 10,
+            }
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {
+                "subscription_event": {
+                    "external_id": "evnt_026",
+                    "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+                    "amount_in_cents": 10,
+                }
+            },
+        )
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_destroy_flat_passthrough_envelope(self, mock_requests):
+        """If caller already wraps in subscription_event, don't double-wrap."""
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = SubscriptionEvent.destroy(
+            config,
+            data={"subscription_event": {"id": 7654321}}
+        ).get()
+
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321}},
+        )
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
+    def test_modify_flat_passthrough_envelope(self, mock_requests):
+        """If caller already wraps in subscription_event, don't double-wrap."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.modify(
+            config,
+            data={"subscription_event": {"id": 7654321, "amount_in_cents": 10}}
+        ).get()
+
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321, "amount_in_cents": 10}},
+        )
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_disable_with_external_id_and_ds_uuid(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.disable(
+            config,
+            data={
+                "external_id": "evnt_026",
+                "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+            }
+        ).get()
+
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["external_id"], "evnt_026")
+        self.assertEqual(
+            body["subscription_event"]["data_source_uuid"],
+            "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+        )
+        self.assertTrue(body["subscription_event"]["disabled"])
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_enable_with_external_id_and_ds_uuid(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.enable(
+            config,
+            data={
+                "external_id": "evnt_026",
+                "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+            }
+        ).get()
+
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["external_id"], "evnt_026")
+        self.assertFalse(body["subscription_event"]["disabled"])
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
     def test_all_subscription_events_with_filters(self, mock_requests):
         mock_requests.register_uri(
             "GET",

--- a/test/api/test_subscription_event.py
+++ b/test/api/test_subscription_event.py
@@ -244,6 +244,87 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertTrue(result is None)
 
     @requests_mock.mock()
+    def test_modify_with_params_new_style(self, mock_requests):
+        """New style: id as a separate kwarg, data for properties."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.modify_with_params(
+            config, id=7654321, data={"amount_in_cents": 10}
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321, "amount_in_cents": 10}},
+        )
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_destroy_with_params_new_style(self, mock_requests):
+        """New style: id as a separate kwarg."""
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = SubscriptionEvent.destroy_with_params(
+            config, id=7654321
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321}},
+        )
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
+    def test_disable_new_style(self, mock_requests):
+        """New style: id as a separate kwarg."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.disable(config, id=7654321).get()
+
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertTrue(body["subscription_event"]["disabled"])
+
+    @requests_mock.mock()
+    def test_enable_new_style(self, mock_requests):
+        """New style: id as a separate kwarg."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.enable(config, id=7654321).get()
+
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertFalse(body["subscription_event"]["disabled"])
+
+    @requests_mock.mock()
     def test_modify_with_params_flat(self, mock_requests):
         mock_requests.register_uri(
             "PATCH",

--- a/test/api/test_subscription_event.py
+++ b/test/api/test_subscription_event.py
@@ -504,3 +504,65 @@ class SubscriptionEventTestCase(unittest.TestCase):
             sorted(expected.subscription_events[0].external_id),
         )
         self.assertTrue(isinstance(subscription_events.subscription_events[0], SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_disable_passthrough_envelope_sets_flag_inside(self, mock_requests):
+        """When caller passes pre-wrapped envelope, disabled flag must go inside it."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        caller_data = {"subscription_event": {"id": 7654321}}
+        config = Config("token")
+        SubscriptionEvent.disable(config, data=caller_data).get()
+
+        body = mock_requests.last_request.json()
+        # disabled must be inside the envelope, not at top level
+        self.assertNotIn("disabled", body)
+        self.assertTrue(body["subscription_event"]["disabled"])
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        # caller's dict must not be mutated
+        self.assertNotIn("disabled", caller_data["subscription_event"])
+
+    @requests_mock.mock()
+    def test_enable_passthrough_envelope_sets_flag_inside(self, mock_requests):
+        """When caller passes pre-wrapped envelope, disabled=False must go inside it."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        caller_data = {"subscription_event": {"id": 7654321}}
+        config = Config("token")
+        SubscriptionEvent.enable(config, data=caller_data).get()
+
+        body = mock_requests.last_request.json()
+        self.assertNotIn("disabled", body)
+        self.assertFalse(body["subscription_event"]["disabled"])
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertNotIn("disabled", caller_data["subscription_event"])
+
+    @requests_mock.mock()
+    def test_disable_does_not_mutate_caller_dict(self, mock_requests):
+        """Flat-param disable must not mutate the caller's dict in-place."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        caller_data = {"id": 7654321}
+        config = Config("token")
+        SubscriptionEvent.disable(config, data=caller_data).get()
+
+        # caller's original dict should not have been modified
+        self.assertNotIn("disabled", caller_data)

--- a/test/api/test_subscription_event.py
+++ b/test/api/test_subscription_event.py
@@ -225,7 +225,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertTrue(isinstance(subscription_events.subscription_events[0], SubscriptionEvent))
 
     @requests_mock.mock()
-    def test_destroy_flat_params(self, mock_requests):
+    def test_destroy_with_params_flat(self, mock_requests):
         mock_requests.register_uri(
             "DELETE",
             "https://api.chartmogul.com/v1/subscription_events",
@@ -234,7 +234,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = SubscriptionEvent.destroy(config, data={"id": 7654321}).get()
+        result = SubscriptionEvent.destroy_with_params(config, data={"id": 7654321}).get()
 
         self.assertEqual(mock_requests.call_count, 1, "expected call")
         self.assertEqual(
@@ -244,7 +244,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertTrue(result is None)
 
     @requests_mock.mock()
-    def test_modify_flat_params(self, mock_requests):
+    def test_modify_with_params_flat(self, mock_requests):
         mock_requests.register_uri(
             "PATCH",
             "https://api.chartmogul.com/v1/subscription_events",
@@ -254,7 +254,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        sub_ev = SubscriptionEvent.modify(
+        sub_ev = SubscriptionEvent.modify_with_params(
             config, data={"id": 7654321, "amount_in_cents": 10}
         ).get()
 
@@ -304,7 +304,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertFalse(body["subscription_event"]["disabled"])
 
     @requests_mock.mock()
-    def test_destroy_flat_with_external_id_and_ds_uuid(self, mock_requests):
+    def test_destroy_with_params_flat_external_id(self, mock_requests):
         mock_requests.register_uri(
             "DELETE",
             "https://api.chartmogul.com/v1/subscription_events",
@@ -313,7 +313,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = SubscriptionEvent.destroy(
+        result = SubscriptionEvent.destroy_with_params(
             config,
             data={
                 "external_id": "evnt_026",
@@ -334,7 +334,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertTrue(result is None)
 
     @requests_mock.mock()
-    def test_modify_flat_with_external_id_and_ds_uuid(self, mock_requests):
+    def test_modify_with_params_flat_external_id(self, mock_requests):
         mock_requests.register_uri(
             "PATCH",
             "https://api.chartmogul.com/v1/subscription_events",
@@ -344,7 +344,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        sub_ev = SubscriptionEvent.modify(
+        sub_ev = SubscriptionEvent.modify_with_params(
             config,
             data={
                 "external_id": "evnt_026",
@@ -367,7 +367,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
 
     @requests_mock.mock()
-    def test_destroy_flat_passthrough_envelope(self, mock_requests):
+    def test_destroy_with_params_envelope_passthrough(self, mock_requests):
         """If caller already wraps in subscription_event, don't double-wrap."""
         mock_requests.register_uri(
             "DELETE",
@@ -377,7 +377,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = SubscriptionEvent.destroy(
+        result = SubscriptionEvent.destroy_with_params(
             config,
             data={"subscription_event": {"id": 7654321}}
         ).get()
@@ -389,7 +389,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertTrue(result is None)
 
     @requests_mock.mock()
-    def test_modify_flat_passthrough_envelope(self, mock_requests):
+    def test_modify_with_params_envelope_passthrough(self, mock_requests):
         """If caller already wraps in subscription_event, don't double-wrap."""
         mock_requests.register_uri(
             "PATCH",
@@ -400,7 +400,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        sub_ev = SubscriptionEvent.modify(
+        sub_ev = SubscriptionEvent.modify_with_params(
             config,
             data={"subscription_event": {"id": 7654321, "amount_in_cents": 10}}
         ).get()

--- a/test/api/test_subscription_event.py
+++ b/test/api/test_subscription_event.py
@@ -225,6 +225,85 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertTrue(isinstance(subscription_events.subscription_events[0], SubscriptionEvent))
 
     @requests_mock.mock()
+    def test_destroy_flat_params(self, mock_requests):
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = SubscriptionEvent.destroy(config, data={"id": 7654321}).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321}},
+        )
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
+    def test_modify_flat_params(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.modify(
+            config, data={"id": 7654321, "amount_in_cents": 10}
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321, "amount_in_cents": 10}},
+        )
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+        self.assertEqual(sub_ev.id, 7654321)
+
+    @requests_mock.mock()
+    def test_disable_subscription_event(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.disable(config, data={"id": 7654321}).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertTrue(body["subscription_event"]["disabled"])
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_enable_subscription_event(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.enable(config, data={"id": 7654321}).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertFalse(body["subscription_event"]["disabled"])
+
+    @requests_mock.mock()
     def test_all_subscription_events_with_filters(self, mock_requests):
         mock_requests.register_uri(
             "GET",

--- a/test/api/test_transaction_external_id.py
+++ b/test/api/test_transaction_external_id.py
@@ -19,6 +19,59 @@ transaction_response = {
 class TransactionExternalIdTestCase(unittest.TestCase):
 
     @requests_mock.mock()
+    def test_retrieve_by_uuid(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/transactions/tr_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=transaction_response,
+        )
+
+        config = Config("token")
+        result = Transaction.retrieve(config, uuid="tr_test").get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(isinstance(result, Transaction))
+        self.assertEqual(result.uuid, "tr_test")
+
+    @requests_mock.mock()
+    def test_modify_by_uuid(self, mock_requests):
+        updated = dict(transaction_response)
+        updated["amount_in_cents"] = 10000
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/transactions/tr_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=updated,
+        )
+
+        config = Config("token")
+        result = Transaction.modify(
+            config, uuid="tr_test", data={"amount_in_cents": 10000}
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(isinstance(result, Transaction))
+
+    @requests_mock.mock()
+    def test_destroy_by_uuid(self, mock_requests):
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/transactions/tr_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = Transaction.destroy(config, uuid="tr_test").get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
     def test_retrieve_with_external_id(self, mock_requests):
         mock_requests.register_uri(
             "GET",

--- a/test/api/test_transaction_external_id.py
+++ b/test/api/test_transaction_external_id.py
@@ -19,7 +19,7 @@ transaction_response = {
 class TransactionExternalIdTestCase(unittest.TestCase):
 
     @requests_mock.mock()
-    def test_retrieve_by_external_id(self, mock_requests):
+    def test_retrieve_with_external_id(self, mock_requests):
         mock_requests.register_uri(
             "GET",
             "https://api.chartmogul.com/v1/transactions"
@@ -30,7 +30,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = Transaction.retrieve_by_external_id(
+        result = Transaction.retrieve(
             config, data_source_uuid="ds_123", external_id="tr_ext_1"
         ).get()
 
@@ -41,7 +41,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         self.assertEqual(result.uuid, "tr_test")
 
     @requests_mock.mock()
-    def test_update_by_external_id(self, mock_requests):
+    def test_modify_with_external_id(self, mock_requests):
         updated = dict(transaction_response)
         updated["amount_in_cents"] = 10000
 
@@ -55,7 +55,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = Transaction.update_by_external_id(
+        result = Transaction.modify(
             config,
             data_source_uuid="ds_123",
             external_id="tr_ext_1",
@@ -67,7 +67,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         self.assertTrue(isinstance(result, Transaction))
 
     @requests_mock.mock()
-    def test_update_by_external_id_with_handle_as_user_edit(self, mock_requests):
+    def test_modify_with_handle_as_user_edit(self, mock_requests):
         mock_requests.register_uri(
             "PATCH",
             "https://api.chartmogul.com/v1/transactions"
@@ -78,7 +78,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        Transaction.update_by_external_id(
+        Transaction.modify(
             config,
             data_source_uuid="ds_123",
             external_id="tr_ext_1",
@@ -91,7 +91,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         )
 
     @requests_mock.mock()
-    def test_destroy_by_external_id(self, mock_requests):
+    def test_destroy_with_external_id(self, mock_requests):
         mock_requests.register_uri(
             "DELETE",
             "https://api.chartmogul.com/v1/transactions"
@@ -101,7 +101,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = Transaction.destroy_by_external_id(
+        result = Transaction.destroy(
             config, data_source_uuid="ds_123", external_id="tr_ext_1"
         ).get()
 
@@ -109,7 +109,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         self.assertTrue(result is None)
 
     @requests_mock.mock()
-    def test_toggle_disabled_by_external_id(self, mock_requests):
+    def test_toggle_disabled(self, mock_requests):
         disabled = dict(transaction_response)
         disabled["disabled"] = True
 
@@ -123,7 +123,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = Transaction.toggle_disabled_by_external_id(
+        result = Transaction.toggle_disabled(
             config,
             data_source_uuid="ds_123",
             external_id="tr_ext_1",
@@ -136,7 +136,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         self.assertTrue(result.disabled)
 
     @requests_mock.mock()
-    def test_destroy_by_external_id_not_found(self, mock_requests):
+    def test_destroy_with_external_id_not_found(self, mock_requests):
         mock_requests.register_uri(
             "DELETE",
             "https://api.chartmogul.com/v1/transactions"
@@ -149,6 +149,6 @@ class TransactionExternalIdTestCase(unittest.TestCase):
 
         config = Config("token")
         with self.assertRaises(APIError):
-            Transaction.destroy_by_external_id(
+            Transaction.destroy(
                 config, data_source_uuid="ds_123", external_id="tr_bad"
             ).get()

--- a/test/api/test_transaction_external_id.py
+++ b/test/api/test_transaction_external_id.py
@@ -1,0 +1,154 @@
+import unittest
+
+import requests_mock
+
+from chartmogul import Transaction, Config, APIError
+
+
+transaction_response = {
+    "uuid": "tr_test",
+    "external_id": "tr_ext_1",
+    "type": "payment",
+    "date": "2025-11-05T00:04:03.000Z",
+    "result": "successful",
+    "amount_in_cents": 5000,
+    "disabled": False,
+}
+
+
+class TransactionExternalIdTestCase(unittest.TestCase):
+
+    @requests_mock.mock()
+    def test_retrieve_by_external_id(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/transactions"
+            "?data_source_uuid=ds_123&external_id=tr_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=transaction_response,
+        )
+
+        config = Config("token")
+        result = Transaction.retrieve_by_external_id(
+            config, data_source_uuid="ds_123", external_id="tr_ext_1"
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertIn("data_source_uuid", mock_requests.last_request.qs)
+        self.assertIn("external_id", mock_requests.last_request.qs)
+        self.assertTrue(isinstance(result, Transaction))
+        self.assertEqual(result.uuid, "tr_test")
+
+    @requests_mock.mock()
+    def test_update_by_external_id(self, mock_requests):
+        updated = dict(transaction_response)
+        updated["amount_in_cents"] = 10000
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/transactions"
+            "?data_source_uuid=ds_123&external_id=tr_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=updated,
+        )
+
+        config = Config("token")
+        result = Transaction.update_by_external_id(
+            config,
+            data_source_uuid="ds_123",
+            external_id="tr_ext_1",
+            data={"amount_in_cents": 10000},
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertEqual(mock_requests.last_request.json(), {"amount_in_cents": 10000})
+        self.assertTrue(isinstance(result, Transaction))
+
+    @requests_mock.mock()
+    def test_update_by_external_id_with_handle_as_user_edit(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/transactions"
+            "?data_source_uuid=ds_123&external_id=tr_ext_1&handle_as_user_edit=true",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=transaction_response,
+        )
+
+        config = Config("token")
+        Transaction.update_by_external_id(
+            config,
+            data_source_uuid="ds_123",
+            external_id="tr_ext_1",
+            handle_as_user_edit=True,
+            data={"amount_in_cents": 5000},
+        ).get()
+
+        self.assertEqual(
+            mock_requests.last_request.qs["handle_as_user_edit"], ["true"]
+        )
+
+    @requests_mock.mock()
+    def test_destroy_by_external_id(self, mock_requests):
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/transactions"
+            "?data_source_uuid=ds_123&external_id=tr_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = Transaction.destroy_by_external_id(
+            config, data_source_uuid="ds_123", external_id="tr_ext_1"
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
+    def test_toggle_disabled_by_external_id(self, mock_requests):
+        disabled = dict(transaction_response)
+        disabled["disabled"] = True
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/transactions/disabled_state"
+            "?data_source_uuid=ds_123&external_id=tr_ext_1",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=disabled,
+        )
+
+        config = Config("token")
+        result = Transaction.toggle_disabled_by_external_id(
+            config,
+            data_source_uuid="ds_123",
+            external_id="tr_ext_1",
+            data={"disabled": True},
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertEqual(mock_requests.last_request.json(), {"disabled": True})
+        self.assertTrue(isinstance(result, Transaction))
+        self.assertTrue(result.disabled)
+
+    @requests_mock.mock()
+    def test_destroy_by_external_id_not_found(self, mock_requests):
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/transactions"
+            "?data_source_uuid=ds_123&external_id=tr_bad",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=404,
+            json={"error": "Transaction not found"},
+        )
+
+        config = Config("token")
+        with self.assertRaises(APIError):
+            Transaction.destroy_by_external_id(
+                config, data_source_uuid="ds_123", external_id="tr_bad"
+            ).get()

--- a/test/api/test_transaction_external_id.py
+++ b/test/api/test_transaction_external_id.py
@@ -152,3 +152,25 @@ class TransactionExternalIdTestCase(unittest.TestCase):
             Transaction.destroy(
                 config, data_source_uuid="ds_123", external_id="tr_bad"
             ).get()
+
+    @requests_mock.mock()
+    def test_disable_by_uuid(self, mock_requests):
+        disabled = dict(transaction_response)
+        disabled["disabled"] = True
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/transactions/tr_test/disabled_state",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=disabled,
+        )
+
+        config = Config("token")
+        result = Transaction.disable(
+            config, uuid="tr_test", data={"disabled": True}
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertTrue(isinstance(result, Transaction))
+        self.assertTrue(result.disabled)

--- a/test/api/test_transaction_external_id.py
+++ b/test/api/test_transaction_external_id.py
@@ -162,7 +162,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         self.assertTrue(result is None)
 
     @requests_mock.mock()
-    def test_toggle_disabled(self, mock_requests):
+    def test_disable(self, mock_requests):
         disabled = dict(transaction_response)
         disabled["disabled"] = True
 
@@ -176,7 +176,7 @@ class TransactionExternalIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = Transaction.toggle_disabled(
+        result = Transaction.disable(
             config,
             data_source_uuid="ds_123",
             external_id="tr_ext_1",


### PR DESCRIPTION
## Summary

- **PIP-304**: Expose `errors` field on `LineItem` and `Transaction` schemas (Invoice already had it)
- **PIP-120 / PIP-76**: Add `id`, `churn_recognition`, `churn_when_zero_mrr` fields to `Account` schema; support `include` query param on `/account`
- **PIP-306**: Add `data_source_uuid` + `external_id` query param support for Invoices, Line Items, and Transactions. All existing methods (`retrieve`, `destroy`, `modify`, `disable`) auto-dispatch to the query-param codepath when `data_source_uuid` + `external_id` are passed instead of `uuid`.
- **Invoice**: Add `update_status` (PATCH `/invoices/{uuid}`) and `disable` (PATCH `/invoices/{uuid}/disabled_state`)
- **LineItem**: New standalone `LineItem` resource with `create` (POST `/import/invoices/{uuid}/line_items`), `retrieve`, `modify`, `destroy`, `disable` — all supporting both uuid and ext_id identification
- **Transaction**: Add standalone `retrieve`, `modify`, `destroy`, `disable` methods at `/transactions` — all supporting both uuid and ext_id identification
- **SubscriptionEvent**: Update `destroy_with_params()` / `modify_with_params()` to accept both flat params and envelope-wrapped params; add `disable()` / `enable()` convenience methods

## Backwards compatibility review

All changes are **purely additive** — no existing public API surface was modified or removed.

| File | Change | Breaking? |
|---|---|---|
| `resource.py` | Added `query_params` param to `_request()`; ext_id dispatch in `_method()` via `_ext_id_path`; `_build_ext_id_params()` helper; `"disable"` in uuid-required validation list | No — default values, no existing caller affected |
| `account.py` | Added `id`, `churn_recognition`, `churn_when_zero_mrr` schema fields | No — `allow_none=True`, old responses still deserialize |
| `invoice.py` | Added `errors`, `disabled`, `disabled_at`, `disabled_by` to nested `LineItem._Schema`; `_ext_id_path`; `update_status`, `disable` methods | No — additive fields and new methods only |
| `transaction.py` | Added `disabled`, `disabled_at`, `disabled_by`, `transaction_fees_currency`, `errors` schema fields; `_ext_id_path`; standalone `retrieve`, `modify`, `destroy`, `disable` methods | No — additive fields and new methods |
| `line_item.py` | **New file** — standalone `LineItem(Resource)` with `create`, `retrieve`, `modify`, `destroy`, `disable` | No — new file, new export |
| `subscription_event.py` | Added `disabled` field to schema; updated `destroy_with_params` / `modify_with_params` to accept flat params; added `disable` / `enable` classmethods | No — envelope-wrapped calls still work; flat params are a new accepted format |
| `__init__.py` | Added `LineItem` export | No — additive |

## Test plan

- [x] Existing 103 tests still pass
- [x] Added 55 new unit tests covering all new methods, both uuid and ext_id paths, error cases, `handle_as_user_edit` support
- [x] 158 total tests passing
- [x] Flake8 linting passes

## Testing instructions

Integration tests were run against account **WiktorOnboarding** (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). To obtain the API key, impersonate `wiktor@chartmogul.com` in the admin panel and find it under Profile > API keys. The full test script is at [`sdks/tests/py/test_pip_310.py`](https://github.com/chartmogul/sdks/blob/main/tests/py/test_pip_310.py) — set the `CHARTMOGUL_API_KEY` env var and run it.

```bash
cd sdks/py
pip3 install -e .
export CHARTMOGUL_API_KEY='...'
python3 sdks/tests/py/test_pip_310.py
```

---

### Account.id field (PIP-120)

```python
account = chartmogul.Account.retrieve(config).get()
assert account.id is not None and account.id.startswith('acc_')
```

### Account include query param (PIP-76)

```python
account = chartmogul.Account.retrieve(
    config, include='churn_recognition,churn_when_zero_mrr'
).get()
assert hasattr(account, 'churn_recognition')
assert hasattr(account, 'churn_when_zero_mrr')

# Without include, fields should be absent
account_basic = chartmogul.Account.retrieve(config).get()
assert not hasattr(account_basic, 'churn_recognition')
```

### LineItem and Transaction errors field (PIP-304)

```python
invoice = chartmogul.Invoice.retrieve(
    config, uuid='inv_...', validation_type='all'
).get()

# Invoice-level errors accessible
print(f"invoice.errors = {getattr(invoice, 'errors', 'NOT SET')}")

# LineItem/Transaction schema supports errors field
# (API omits the key when no validation errors exist)
for li in invoice.line_items:
    print(f"li.errors = {getattr(li, 'errors', 'absent (no errors)')}")
```

### Invoice.update_status

```python
# PUT /data_sources/{ds_uuid}/invoices/{external_id}/status
# Valid statuses: "voided", "written_off"
result = chartmogul.Invoice.update_status(
    config,
    uuid='inv_...',
    data={'status': 'voided'}
).get()
```

### Invoice.disable (uuid-based)

```python
# PATCH /invoices/{uuid}/disabled_state
chartmogul.Invoice.disable(
    config, uuid='inv_...', data={'disabled': True}
).get()

# Missing uuid raises ArgumentMissingError
try:
    chartmogul.Invoice.disable(config)
except chartmogul.ArgumentMissingError:
    print("Correctly raised")
```

### Invoice.disable (ext_id-based, PIP-306)

```python
# PATCH /invoices/disabled_state?data_source_uuid=...&external_id=...
chartmogul.Invoice.disable(
    config,
    data_source_uuid='ds_...',
    external_id='inv_ext_...',
    data={'disabled': True}
).get()
```

### Invoice.retrieve (ext_id-based, PIP-306)

```python
# GET /invoices?data_source_uuid=...&external_id=...
result = chartmogul.Invoice.retrieve(
    config,
    data_source_uuid='ds_...',
    external_id='in_...'
).get()
assert len(result.invoices) > 0
```

### Invoice.update_status (ext_id-based, PIP-306)

```python
# PATCH /invoices?data_source_uuid=...&external_id=...
result = chartmogul.Invoice.update_status(
    config,
    data_source_uuid='ds_...',
    external_id='in_...',
    data={'currency': 'USD'}
).get()

# With handle_as_user_edit
result = chartmogul.Invoice.update_status(
    config,
    data_source_uuid='ds_...',
    external_id='in_...',
    handle_as_user_edit=True,
    data={'currency': 'USD'}
).get()
```

### Invoice.destroy (ext_id-based, PIP-306)

```python
# DELETE /invoices?data_source_uuid=...&external_id=...
chartmogul.Invoice.destroy(
    config,
    data_source_uuid='ds_...',
    external_id='in_...'
).get()
```

### LineItem — all operations (PIP-306)

```python
# Create (POST /import/invoices/{uuid}/line_items)
li = chartmogul.LineItem.create(
    config, uuid='inv_...', data={...}
).get()

# Retrieve by uuid
li = chartmogul.LineItem.retrieve(config, uuid='li_...').get()

# Retrieve by ext_id
li = chartmogul.LineItem.retrieve(
    config, data_source_uuid='ds_...', external_id='li_ext_...'
).get()

# Modify by uuid
chartmogul.LineItem.modify(config, uuid='li_...', data={...}).get()

# Modify by ext_id (with handle_as_user_edit)
chartmogul.LineItem.modify(
    config, data_source_uuid='ds_...', external_id='li_ext_...',
    handle_as_user_edit=True, data={...}
).get()

# Destroy by uuid
chartmogul.LineItem.destroy(config, uuid='li_...').get()

# Destroy by ext_id
chartmogul.LineItem.destroy(
    config, data_source_uuid='ds_...', external_id='li_ext_...'
).get()

# Disable by uuid
chartmogul.LineItem.disable(
    config, uuid='li_...', data={'disabled': True}
).get()

# Disable by ext_id
chartmogul.LineItem.disable(
    config, data_source_uuid='ds_...', external_id='li_ext_...',
    data={'disabled': True}
).get()
```

### Transaction — all operations (PIP-306)

```python
# Retrieve / modify / destroy / disable all support both uuid and ext_id:
tx = chartmogul.Transaction.retrieve(config, uuid='tr_...').get()
tx = chartmogul.Transaction.retrieve(
    config, data_source_uuid='ds_...', external_id='tr_ext_...'
).get()

chartmogul.Transaction.disable(
    config, uuid='tr_...', data={'disabled': True}
).get()
chartmogul.Transaction.disable(
    config, data_source_uuid='ds_...', external_id='tr_ext_...',
    data={'disabled': True}
).get()
```

### SubscriptionEvent.modify_with_params — flat and envelope

```python
# Flat params (auto-wrapped into subscription_event envelope)
se = chartmogul.SubscriptionEvent.modify_with_params(
    config, data={'id': 123}
).get()

# Envelope passthrough (already wrapped — passed through as-is)
se = chartmogul.SubscriptionEvent.modify_with_params(
    config, data={'subscription_event': {'id': 123}}
).get()
```

### SubscriptionEvent.destroy_with_params — flat and envelope

```python
# Flat params
chartmogul.SubscriptionEvent.destroy_with_params(
    config, data={'id': 123}
).get()

# Also works with external_id + data_source_uuid
chartmogul.SubscriptionEvent.destroy_with_params(
    config, data={'external_id': '...', 'data_source_uuid': 'ds_...'}
).get()

# Envelope passthrough
chartmogul.SubscriptionEvent.destroy_with_params(
    config, data={'subscription_event': {'id': 123}}
).get()
```

### SubscriptionEvent.disable and enable

```python
se = chartmogul.SubscriptionEvent.disable(config, data={'id': 123}).get()
se = chartmogul.SubscriptionEvent.enable(config, data={'id': 123}).get()

# Works with external_id + data_source_uuid
chartmogul.SubscriptionEvent.disable(
    config, data={'external_id': '...', 'data_source_uuid': 'ds_...'}
).get()

# Works with envelope
chartmogul.SubscriptionEvent.disable(
    config, data={'subscription_event': {'id': 123}}
).get()
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)