### PR TITLE
Add account ID field support (PIP-120)

### DIFF
--- a/chartmogul/api/account.py
+++ b/chartmogul/api/account.py
@@ -10,6 +10,7 @@ class Account(Resource):
     _path = "/account"
 
     class _Schema(Schema):
+        id = fields.String(allow_none=True)
         name = fields.String()
         currency = fields.String()
         time_zone = fields.String()

--- a/test/api/test_account.py
+++ b/test/api/test_account.py
@@ -35,3 +35,46 @@ class AccountTestCase(unittest.TestCase):
         self.assertEqual(account.currency, "EUR")
         self.assertEqual(account.time_zone, "Europe/Berlin")
         self.assertEqual(account.week_start_on, "sunday")
+
+
+jsonResponseWithId = {
+    "id": "acct_a1b2c3d4",
+    "name": "Example Test Company",
+    "currency": "EUR",
+    "time_zone": "Europe/Berlin",
+    "week_start_on": "sunday",
+}
+
+
+class AccountIdTestCase(unittest.TestCase):
+
+    @requests_mock.mock()
+    def test_retrieve_with_id(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/account",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=jsonResponseWithId,
+        )
+
+        config = Config("token")
+        account = Account.retrieve(config).get()
+        self.assertTrue(isinstance(account, Account))
+        self.assertEqual(account.id, "acct_a1b2c3d4")
+
+    @requests_mock.mock()
+    def test_retrieve_without_id_field(self, mock_requests):
+        """Old API responses without id field should not break deserialization."""
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/account",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=jsonResponse,
+        )
+
+        config = Config("token")
+        account = Account.retrieve(config).get()
+        self.assertTrue(isinstance(account, Account))
+        self.assertFalse(hasattr(account, "id"))


### PR DESCRIPTION
## Summary

`Account.retrieve()` now exposes the `id` field from the API response.

## Backwards compatibility

| Change | Breaking? |
|---|---|
| Added `id = fields.String(allow_none=True)` to Account schema | No — old responses without this field still deserialize correctly |

## Testing instructions

Test account: **WiktorOnboarding** (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). Impersonate `wiktor@chartmogul.com` for API key.

```python
account = chartmogul.Account.retrieve(config).get()
assert account.id is not None and account.id.startswith('acc_')
```

## Test plan

- [x] Added 2 tests: retrieve with id, retrieve without id (backwards compat)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)