### PR TITLE
Add include query param support for Account (PIP-76)

### DIFF
--- a/chartmogul/api/account.py
+++ b/chartmogul/api/account.py
@@ -15,6 +15,8 @@ class Account(Resource):
         currency = fields.String()
         time_zone = fields.String()
         week_start_on = fields.String()
+        churn_recognition = fields.String(allow_none=True)
+        churn_when_zero_mrr = fields.Raw(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):

--- a/test/api/test_account.py
+++ b/test/api/test_account.py
@@ -78,3 +78,64 @@ class AccountIdTestCase(unittest.TestCase):
         account = Account.retrieve(config).get()
         self.assertTrue(isinstance(account, Account))
         self.assertFalse(hasattr(account, "id"))
+
+
+jsonResponseWithInclude = {
+    "name": "Example Test Company",
+    "currency": "EUR",
+    "time_zone": "Europe/Berlin",
+    "week_start_on": "sunday",
+    "churn_recognition": "immediate",
+    "churn_when_zero_mrr": "ignore",
+}
+
+
+class AccountIncludeTestCase(unittest.TestCase):
+
+    @requests_mock.mock()
+    def test_retrieve_with_include(self, mock_requests):
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/account?include=churn_recognition,churn_when_zero_mrr",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=jsonResponseWithInclude,
+        )
+
+        config = Config("token")
+        account = Account.retrieve(
+            config, include="churn_recognition,churn_when_zero_mrr"
+        ).get()
+        self.assertTrue(isinstance(account, Account))
+        self.assertEqual(account.churn_recognition, "immediate")
+        self.assertEqual(account.churn_when_zero_mrr, "ignore")
+        self.assertEqual(
+            mock_requests.last_request.qs,
+            {"include": ["churn_recognition,churn_when_zero_mrr"]},
+        )
+
+    @requests_mock.mock()
+    def test_retrieve_with_single_include(self, mock_requests):
+        singleIncludeResponse = {
+            "name": "Example Test Company",
+            "currency": "EUR",
+            "time_zone": "Europe/Berlin",
+            "week_start_on": "sunday",
+            "churn_recognition": "immediate",
+        }
+
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/account?include=churn_recognition",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=singleIncludeResponse,
+        )
+
+        config = Config("token")
+        account = Account.retrieve(config, include="churn_recognition").get()
+        self.assertTrue(isinstance(account, Account))
+        self.assertEqual(account.churn_recognition, "immediate")
+        self.assertFalse(hasattr(account, "churn_when_zero_mrr"))


### PR DESCRIPTION
## Summary

`Account.retrieve()` now supports the `include` query param to request additional fields like `churn_recognition` and `churn_when_zero_mrr`.

## Backwards compatibility

| Change | Breaking? |
|---|---|
| Added `churn_recognition = fields.String(allow_none=True)` to Account schema | No — field absent when `include` not used |
| Added `churn_when_zero_mrr = fields.Raw(allow_none=True)` to Account schema | No — `Raw` type handles both string and boolean API responses |

## Testing instructions

Test account: **WiktorOnboarding** (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). Impersonate `wiktor@chartmogul.com` for API key.

```python
account = chartmogul.Account.retrieve(
    config, include='churn_recognition,churn_when_zero_mrr'
).get()
assert hasattr(account, 'churn_recognition')
assert hasattr(account, 'churn_when_zero_mrr')

# Without include, fields should be absent
account_basic = chartmogul.Account.retrieve(config).get()
assert not hasattr(account_basic, 'churn_recognition')
```

## Test plan

- [x] Added 2 tests: retrieve with include (both fields), retrieve with single include
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)