### PR TITLE
Expose validation errors on LineItem and Transaction schemas (PIP-304)

### DIFF
--- a/chartmogul/api/invoice.py
+++ b/chartmogul/api/invoice.py
@@ -27,6 +27,7 @@ class LineItem(DataObject):
         account_code = fields.String(allow_none=True)
         description = fields.String(allow_none=True)
         event_order = fields.Int(allow_none=True)
+        errors = fields.Dict(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):

--- a/chartmogul/api/transaction.py
+++ b/chartmogul/api/transaction.py
@@ -17,6 +17,7 @@ class Transaction(Resource):
         result = fields.String()
         amount_in_cents = fields.Int(allow_none=True)
         transaction_fees_in_cents = fields.Int(allow_none=True)
+        errors = fields.Dict(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):

--- a/test/api/test_invoice.py
+++ b/test/api/test_invoice.py
@@ -621,3 +621,172 @@ class InvoiceTestCase(unittest.TestCase):
         self.assertEqual(qs["with_disabled"], ["true"])
         self.assertTrue(isinstance(result, Invoice._many))
         self.assertEqual(len(result.invoices), 1)
+
+    def _make_errors_response(self, li_errors=None, tx_errors=None, include_errors=True):
+        """Build a minimal invoice response with configurable errors fields."""
+        li = {
+            "uuid": "li_test",
+            "external_id": None,
+            "type": "subscription",
+            "prorated": False,
+            "amount_in_cents": 5000,
+            "quantity": 1,
+            "discount_amount_in_cents": 0,
+            "tax_amount_in_cents": 0,
+            "transaction_fees_in_cents": 0,
+        }
+        tx = {
+            "uuid": "tr_test",
+            "external_id": None,
+            "type": "payment",
+            "date": "2015-11-05T00:04:03.000Z",
+            "result": "successful",
+        }
+        if include_errors:
+            li["errors"] = li_errors
+            tx["errors"] = tx_errors
+        return {
+            "uuid": "inv_test",
+            "external_id": "INV0001",
+            "date": "2015-11-01T00:00:00.000Z",
+            "due_date": "2015-11-15T00:00:00.000Z",
+            "currency": "USD",
+            "line_items": [li],
+            "transactions": [tx],
+        }
+
+    @requests_mock.mock()
+    def test_line_item_and_transaction_errors(self, mock_requests):
+        response = self._make_errors_response(
+            li_errors={"amount_in_cents": ["must be positive"]},
+            tx_errors={"date": ["is in the future"]},
+        )
+
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/invoices/inv_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=response,
+        )
+
+        config = Config("token")
+        result = Invoice.retrieve(config, uuid="inv_test").get()
+
+        self.assertTrue(isinstance(result, Invoice))
+        self.assertIsNotNone(result.line_items[0].errors)
+        self.assertEqual(result.line_items[0].errors["amount_in_cents"], ["must be positive"])
+        self.assertIsNotNone(result.transactions[0].errors)
+        self.assertEqual(result.transactions[0].errors["date"], ["is in the future"])
+
+    @requests_mock.mock()
+    def test_line_item_errors_none(self, mock_requests):
+        response = self._make_errors_response(li_errors=None, tx_errors=None)
+
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/invoices/inv_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=response,
+        )
+
+        config = Config("token")
+        result = Invoice.retrieve(config, uuid="inv_test").get()
+
+        self.assertTrue(isinstance(result, Invoice))
+        self.assertIsNone(result.line_items[0].errors)
+        self.assertIsNone(result.transactions[0].errors)
+
+    @requests_mock.mock()
+    def test_line_item_errors_absent(self, mock_requests):
+        response = self._make_errors_response(include_errors=False)
+
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/invoices/inv_test_no_errors",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=response,
+        )
+
+        config = Config("token")
+        result = Invoice.retrieve(config, uuid="inv_test_no_errors").get()
+
+        self.assertTrue(isinstance(result, Invoice))
+        # When errors field is absent from response, the attribute should not be set
+        self.assertFalse(hasattr(result.line_items[0], "errors"))
+        self.assertFalse(hasattr(result.transactions[0], "errors"))
+
+
+class InvoiceErrorsTestCase(unittest.TestCase):
+    """Tests for PIP-304: errors field on LineItem and Transaction."""
+
+    def _make_errors_response(self, li_errors=None, tx_errors=None, include_errors=True):
+        li = {
+            "uuid": "li_test", "external_id": None, "type": "subscription",
+            "prorated": False, "amount_in_cents": 5000, "quantity": 1,
+            "discount_amount_in_cents": 0, "tax_amount_in_cents": 0,
+            "transaction_fees_in_cents": 0,
+        }
+        tx = {
+            "uuid": "tr_test", "external_id": None, "type": "payment",
+            "date": "2015-11-05T00:04:03.000Z", "result": "successful",
+        }
+        if include_errors:
+            li["errors"] = li_errors
+            tx["errors"] = tx_errors
+        return {
+            "uuid": "inv_test", "external_id": "INV0001",
+            "date": "2015-11-01T00:00:00.000Z", "due_date": "2015-11-15T00:00:00.000Z",
+            "currency": "USD", "line_items": [li], "transactions": [tx],
+        }
+
+    @requests_mock.mock()
+    def test_line_item_and_transaction_errors(self, mock_requests):
+        response = self._make_errors_response(
+            li_errors={"amount_in_cents": ["must be positive"]},
+            tx_errors={"date": ["is in the future"]},
+        )
+        mock_requests.register_uri(
+            "GET", "https://api.chartmogul.com/v1/invoices/inv_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200, json=response,
+        )
+        config = Config("token")
+        result = Invoice.retrieve(config, uuid="inv_test").get()
+        self.assertTrue(isinstance(result, Invoice))
+        self.assertEqual(result.line_items[0].errors["amount_in_cents"], ["must be positive"])
+        self.assertEqual(result.transactions[0].errors["date"], ["is in the future"])
+
+    @requests_mock.mock()
+    def test_line_item_errors_none(self, mock_requests):
+        response = self._make_errors_response(li_errors=None, tx_errors=None)
+        mock_requests.register_uri(
+            "GET", "https://api.chartmogul.com/v1/invoices/inv_test",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200, json=response,
+        )
+        config = Config("token")
+        result = Invoice.retrieve(config, uuid="inv_test").get()
+        self.assertIsNone(result.line_items[0].errors)
+        self.assertIsNone(result.transactions[0].errors)
+
+    @requests_mock.mock()
+    def test_line_item_errors_absent(self, mock_requests):
+        response = self._make_errors_response(include_errors=False)
+        mock_requests.register_uri(
+            "GET", "https://api.chartmogul.com/v1/invoices/inv_test_no_errors",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200, json=response,
+        )
+        config = Config("token")
+        result = Invoice.retrieve(config, uuid="inv_test_no_errors").get()
+        self.assertFalse(hasattr(result.line_items[0], "errors"))
+        self.assertFalse(hasattr(result.transactions[0], "errors"))


### PR DESCRIPTION
## Summary

LineItem and Transaction schemas now include an `errors` field (`Dict`, `allow_none=True`) matching Invoice's existing errors field. When retrieving an invoice with `validation_type='all'`, line item and transaction validation errors are now accessible.

## Backwards compatibility

| Change | Breaking? |
|---|---|
| Added `errors = fields.Dict(allow_none=True)` to LineItem._Schema | No — additive field, absent when API doesn't return it |
| Added `errors = fields.Dict(allow_none=True)` to Transaction._Schema | No — additive field |

## Testing instructions

Test account: **WiktorOnboarding** (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). Impersonate `wiktor@chartmogul.com` for API key.

```python
invoice = chartmogul.Invoice.retrieve(
    config, uuid='inv_e81f78fc-00ab-4a16-95ab-d1f0cd9cd481',
    validation_type='all'
).get()

print(f"invoice.errors = {getattr(invoice, 'errors', 'NOT SET')}")
for li in invoice.line_items:
    print(f"li.errors = {getattr(li, 'errors', 'absent (no errors)')}")
```

## Test plan

- [x] Added 3 tests: errors present, errors None, errors absent
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)