### PR TITLE
Update SubscriptionEvent: flat params, disable/enable (PIP-310)

### DIFF
--- a/chartmogul/api/subscription_event.py
+++ b/chartmogul/api/subscription_event.py
@@ -71,7 +71,10 @@ class SubscriptionEvent(Resource):
 
     @classmethod
     def disable(cls, config, **kwargs):
-        """Disable a subscription event by setting disabled to true."""
+        """Disable a subscription event. Supports id path param or body-based."""
+        if "id" in kwargs and "data" not in kwargs:
+            return cls._disable_by_id(
+                config, id=kwargs["id"], data={"disabled": True})
         data = dict(kwargs.get("data", {}))
         if "subscription_event" in data:
             data = dict(data["subscription_event"])
@@ -83,7 +86,10 @@ class SubscriptionEvent(Resource):
 
     @classmethod
     def enable(cls, config, **kwargs):
-        """Enable a subscription event by setting disabled to false."""
+        """Enable a subscription event. Supports id path param or body-based."""
+        if "id" in kwargs and "data" not in kwargs:
+            return cls._disable_by_id(
+                config, id=kwargs["id"], data={"disabled": False})
         data = dict(kwargs.get("data", {}))
         if "subscription_event" in data:
             data = dict(data["subscription_event"])
@@ -100,5 +106,5 @@ SubscriptionEvent._destroy_raw = SubscriptionEvent._method(
     "destroy_with_params", "delete", "/subscription_events")
 SubscriptionEvent._modify_raw = SubscriptionEvent._method(
     "modify_with_params", "patch", "/subscription_events")
-SubscriptionEvent.disable_by_id = SubscriptionEvent._method(
+SubscriptionEvent._disable_by_id = SubscriptionEvent._method(
     "disable_by_id", "patch", "/subscription_events{/id}/disabled_state")

--- a/chartmogul/api/subscription_event.py
+++ b/chartmogul/api/subscription_event.py
@@ -100,3 +100,5 @@ SubscriptionEvent._destroy_raw = SubscriptionEvent._method(
     "destroy_with_params", "delete", "/subscription_events")
 SubscriptionEvent._modify_raw = SubscriptionEvent._method(
     "modify_with_params", "patch", "/subscription_events")
+SubscriptionEvent.disable_by_id = SubscriptionEvent._method(
+    "disable_by_id", "patch", "/subscription_events{/id}/disabled_state")

--- a/chartmogul/api/subscription_event.py
+++ b/chartmogul/api/subscription_event.py
@@ -32,6 +32,8 @@ class SubscriptionEvent(Resource):
         external_id = fields.String(allow_none=True)
         event_order = fields.Int(allow_none=True)
         disabled = fields.Bool(allow_none=True)
+        disabled_at = fields.DateTime(allow_none=True)
+        disabled_by = fields.String(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):

--- a/chartmogul/api/subscription_event.py
+++ b/chartmogul/api/subscription_event.py
@@ -31,6 +31,7 @@ class SubscriptionEvent(Resource):
         retracted_event_id = fields.String(allow_none=True)
         external_id = fields.String(allow_none=True)
         event_order = fields.Int(allow_none=True)
+        disabled = fields.Bool(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):
@@ -38,11 +39,64 @@ class SubscriptionEvent(Resource):
 
     _schema = _Schema(unknown=EXCLUDE)
 
+    @classmethod
+    def _wrap_envelope(cls, kwargs):
+        """Wrap params in subscription_event envelope.
 
-SubscriptionEvent.all = SubscriptionEvent._method("all", "get", "/subscription_events")
-SubscriptionEvent.destroy_with_params = SubscriptionEvent._method(
-    "destroy_with_params", "delete", "/subscription_events"
-)
-SubscriptionEvent.modify_with_params = SubscriptionEvent._method(
-    "modify_with_params", "patch", "/subscription_events"
-)
+        Supports three call styles (all backwards compatible):
+        1. New style:     (config, id=123, data={'amount': 2000})
+        2. Flat style:    (config, data={'id': 123, 'amount': 2000})
+        3. Envelope style:(config, data={'subscription_event': {'id': 123}})
+        """
+        data = dict(kwargs.get("data", {}))
+        if "subscription_event" in data:
+            return data
+        # Merge top-level id/external_id/data_source_uuid into data
+        for key in ("id", "external_id", "data_source_uuid"):
+            if key in kwargs:
+                data[key] = kwargs[key]
+        return {"subscription_event": data}
+
+    @classmethod
+    def destroy_with_params(cls, config, **kwargs):
+        """DELETE /subscription_events. Accepts flat or envelope-wrapped params."""
+        kwargs["data"] = cls._wrap_envelope(kwargs)
+        return cls._destroy_raw(config, **kwargs)
+
+    @classmethod
+    def modify_with_params(cls, config, **kwargs):
+        """PATCH /subscription_events. Accepts flat or envelope-wrapped params."""
+        kwargs["data"] = cls._wrap_envelope(kwargs)
+        return cls._modify_raw(config, **kwargs)
+
+    @classmethod
+    def disable(cls, config, **kwargs):
+        """Disable a subscription event by setting disabled to true."""
+        data = dict(kwargs.get("data", {}))
+        if "subscription_event" in data:
+            data = dict(data["subscription_event"])
+        for key in ("id", "external_id", "data_source_uuid"):
+            if key in kwargs:
+                data[key] = kwargs[key]
+        data["disabled"] = True
+        return cls.modify_with_params(config, data=data)
+
+    @classmethod
+    def enable(cls, config, **kwargs):
+        """Enable a subscription event by setting disabled to false."""
+        data = dict(kwargs.get("data", {}))
+        if "subscription_event" in data:
+            data = dict(data["subscription_event"])
+        for key in ("id", "external_id", "data_source_uuid"):
+            if key in kwargs:
+                data[key] = kwargs[key]
+        data["disabled"] = False
+        return cls.modify_with_params(config, data=data)
+
+
+SubscriptionEvent.all = SubscriptionEvent._method(
+    "all", "get", "/subscription_events")
+SubscriptionEvent._destroy_raw = SubscriptionEvent._method(
+    "destroy_with_params", "delete", "/subscription_events")
+SubscriptionEvent._modify_raw = SubscriptionEvent._method(
+    "modify_with_params", "patch", "/subscription_events")

--- a/chartmogul/api/subscription_event.py
+++ b/chartmogul/api/subscription_event.py
@@ -70,34 +70,54 @@ class SubscriptionEvent(Resource):
         return cls._modify_raw(config, **kwargs)
 
     @classmethod
-    def disable(cls, config, **kwargs):
-        """Disable a subscription event. Supports id path param or body-based."""
+    def _resolve_disable_params(cls, kwargs):
+        """Extract identification params for the /disabled_state endpoint.
+
+        Returns (id_or_none, body_data) where:
+        - id_or_none: numeric id for path param, or None for body-based
+        - body_data: dict with {disabled: bool} plus optional identifiers
+        """
+        # Top-level id kwarg
         if "id" in kwargs and "data" not in kwargs:
-            return cls._disable_by_id(
-                config, id=kwargs["id"], data={"disabled": True})
+            return kwargs["id"], {}
+        # Unwrap data
         data = dict(kwargs.get("data", {}))
         if "subscription_event" in data:
             data = dict(data["subscription_event"])
+        # Merge top-level kwargs into data
         for key in ("id", "external_id", "data_source_uuid"):
-            if key in kwargs:
+            if key in kwargs and key not in data:
                 data[key] = kwargs[key]
-        data["disabled"] = True
-        return cls.modify_with_params(config, data=data)
+        # Route by id (path param) or external_id+data_source_uuid (body)
+        if "id" in data:
+            return data["id"], {}
+        if "external_id" in data and "data_source_uuid" in data:
+            return None, {
+                "external_id": data["external_id"],
+                "data_source_uuid": data["data_source_uuid"],
+            }
+        raise ValueError(
+            "disable/enable requires either 'id' or both "
+            "'external_id' and 'data_source_uuid'."
+        )
+
+    @classmethod
+    def disable(cls, config, **kwargs):
+        """Disable a subscription event by id or external_id+data_source_uuid."""
+        event_id, body = cls._resolve_disable_params(kwargs)
+        body["disabled"] = True
+        if event_id is not None:
+            return cls._disable_by_id(config, id=event_id, data=body)
+        return cls._disable_body(config, data=body)
 
     @classmethod
     def enable(cls, config, **kwargs):
-        """Enable a subscription event. Supports id path param or body-based."""
-        if "id" in kwargs and "data" not in kwargs:
-            return cls._disable_by_id(
-                config, id=kwargs["id"], data={"disabled": False})
-        data = dict(kwargs.get("data", {}))
-        if "subscription_event" in data:
-            data = dict(data["subscription_event"])
-        for key in ("id", "external_id", "data_source_uuid"):
-            if key in kwargs:
-                data[key] = kwargs[key]
-        data["disabled"] = False
-        return cls.modify_with_params(config, data=data)
+        """Enable a subscription event by id or external_id+data_source_uuid."""
+        event_id, body = cls._resolve_disable_params(kwargs)
+        body["disabled"] = False
+        if event_id is not None:
+            return cls._disable_by_id(config, id=event_id, data=body)
+        return cls._disable_body(config, data=body)
 
 
 SubscriptionEvent.all = SubscriptionEvent._method(
@@ -108,3 +128,5 @@ SubscriptionEvent._modify_raw = SubscriptionEvent._method(
     "modify_with_params", "patch", "/subscription_events")
 SubscriptionEvent._disable_by_id = SubscriptionEvent._method(
     "disable_by_id", "patch", "/subscription_events{/id}/disabled_state")
+SubscriptionEvent._disable_body = SubscriptionEvent._method(
+    "disable_body", "patch", "/subscription_events/disabled_state")

--- a/test/api/test_subscription_event.py
+++ b/test/api/test_subscription_event.py
@@ -350,9 +350,10 @@ class SubscriptionEventTestCase(unittest.TestCase):
 
     @requests_mock.mock()
     def test_disable_subscription_event(self, mock_requests):
+        """disable(data={'id': ...}) routes to /disabled_state endpoint."""
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/subscription_events",
+            "https://api.chartmogul.com/v1/subscription_events/7654321/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
             json=expected_sub_ev,
@@ -362,16 +363,15 @@ class SubscriptionEventTestCase(unittest.TestCase):
         sub_ev = SubscriptionEvent.disable(config, data={"id": 7654321}).get()
 
         self.assertEqual(mock_requests.call_count, 1, "expected call")
-        body = mock_requests.last_request.json()
-        self.assertEqual(body["subscription_event"]["id"], 7654321)
-        self.assertTrue(body["subscription_event"]["disabled"])
+        self.assertEqual(mock_requests.last_request.json(), {"disabled": True})
         self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
 
     @requests_mock.mock()
     def test_enable_subscription_event(self, mock_requests):
+        """enable(data={'id': ...}) routes to /disabled_state endpoint."""
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/subscription_events",
+            "https://api.chartmogul.com/v1/subscription_events/7654321/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
             json=expected_sub_ev,
@@ -381,9 +381,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         sub_ev = SubscriptionEvent.enable(config, data={"id": 7654321}).get()
 
         self.assertEqual(mock_requests.call_count, 1, "expected call")
-        body = mock_requests.last_request.json()
-        self.assertEqual(body["subscription_event"]["id"], 7654321)
-        self.assertFalse(body["subscription_event"]["disabled"])
+        self.assertEqual(mock_requests.last_request.json(), {"disabled": False})
 
     @requests_mock.mock()
     def test_destroy_with_params_flat_external_id(self, mock_requests):
@@ -495,9 +493,10 @@ class SubscriptionEventTestCase(unittest.TestCase):
 
     @requests_mock.mock()
     def test_disable_with_external_id_and_ds_uuid(self, mock_requests):
+        """disable with external_id+data_source_uuid uses body-based /disabled_state."""
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/subscription_events",
+            "https://api.chartmogul.com/v1/subscription_events/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
             json=expected_sub_ev,
@@ -513,19 +512,17 @@ class SubscriptionEventTestCase(unittest.TestCase):
         ).get()
 
         body = mock_requests.last_request.json()
-        self.assertEqual(body["subscription_event"]["external_id"], "evnt_026")
-        self.assertEqual(
-            body["subscription_event"]["data_source_uuid"],
-            "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
-        )
-        self.assertTrue(body["subscription_event"]["disabled"])
+        self.assertEqual(body["external_id"], "evnt_026")
+        self.assertEqual(body["data_source_uuid"], "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba")
+        self.assertTrue(body["disabled"])
         self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
 
     @requests_mock.mock()
     def test_enable_with_external_id_and_ds_uuid(self, mock_requests):
+        """enable with external_id+data_source_uuid uses body-based /disabled_state."""
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/subscription_events",
+            "https://api.chartmogul.com/v1/subscription_events/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
             json=expected_sub_ev,
@@ -541,9 +538,15 @@ class SubscriptionEventTestCase(unittest.TestCase):
         ).get()
 
         body = mock_requests.last_request.json()
-        self.assertEqual(body["subscription_event"]["external_id"], "evnt_026")
-        self.assertFalse(body["subscription_event"]["disabled"])
+        self.assertEqual(body["external_id"], "evnt_026")
+        self.assertFalse(body["disabled"])
         self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    def test_disable_missing_identifiers_raises_error(self):
+        """disable without id or external_id+data_source_uuid raises ValueError."""
+        config = Config("token")
+        with self.assertRaises(ValueError):
+            SubscriptionEvent.disable(config, data={"amount_in_cents": 100})
 
     @requests_mock.mock()
     def test_all_subscription_events_with_filters(self, mock_requests):
@@ -588,11 +591,11 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertTrue(isinstance(subscription_events.subscription_events[0], SubscriptionEvent))
 
     @requests_mock.mock()
-    def test_disable_passthrough_envelope_sets_flag_inside(self, mock_requests):
-        """When caller passes pre-wrapped envelope, disabled flag must go inside it."""
+    def test_disable_passthrough_envelope_routes_to_disabled_state(self, mock_requests):
+        """When caller passes pre-wrapped envelope, id is extracted and routed to /disabled_state."""
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/subscription_events",
+            "https://api.chartmogul.com/v1/subscription_events/7654321/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
             json=expected_sub_ev,
@@ -602,20 +605,16 @@ class SubscriptionEventTestCase(unittest.TestCase):
         config = Config("token")
         SubscriptionEvent.disable(config, data=caller_data).get()
 
-        body = mock_requests.last_request.json()
-        # disabled must be inside the envelope, not at top level
-        self.assertNotIn("disabled", body)
-        self.assertTrue(body["subscription_event"]["disabled"])
-        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertEqual(mock_requests.last_request.json(), {"disabled": True})
         # caller's dict must not be mutated
         self.assertNotIn("disabled", caller_data["subscription_event"])
 
     @requests_mock.mock()
-    def test_enable_passthrough_envelope_sets_flag_inside(self, mock_requests):
-        """When caller passes pre-wrapped envelope, disabled=False must go inside it."""
+    def test_enable_passthrough_envelope_routes_to_disabled_state(self, mock_requests):
+        """When caller passes pre-wrapped envelope, id is extracted and routed to /disabled_state."""
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/subscription_events",
+            "https://api.chartmogul.com/v1/subscription_events/7654321/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
             json=expected_sub_ev,
@@ -625,10 +624,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         config = Config("token")
         SubscriptionEvent.enable(config, data=caller_data).get()
 
-        body = mock_requests.last_request.json()
-        self.assertNotIn("disabled", body)
-        self.assertFalse(body["subscription_event"]["disabled"])
-        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertEqual(mock_requests.last_request.json(), {"disabled": False})
         self.assertNotIn("disabled", caller_data["subscription_event"])
 
     @requests_mock.mock()
@@ -636,7 +632,7 @@ class SubscriptionEventTestCase(unittest.TestCase):
         """Flat-param disable must not mutate the caller's dict in-place."""
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/subscription_events",
+            "https://api.chartmogul.com/v1/subscription_events/7654321/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
             json=expected_sub_ev,

--- a/test/api/test_subscription_event.py
+++ b/test/api/test_subscription_event.py
@@ -290,10 +290,10 @@ class SubscriptionEventTestCase(unittest.TestCase):
 
     @requests_mock.mock()
     def test_disable_new_style(self, mock_requests):
-        """New style: id as a separate kwarg."""
+        """New style: id as a separate kwarg uses path-param endpoint."""
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/subscription_events",
+            "https://api.chartmogul.com/v1/subscription_events/7654321/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
             json=expected_sub_ev,
@@ -302,27 +302,28 @@ class SubscriptionEventTestCase(unittest.TestCase):
         config = Config("token")
         sub_ev = SubscriptionEvent.disable(config, id=7654321).get()
 
-        body = mock_requests.last_request.json()
-        self.assertEqual(body["subscription_event"]["id"], 7654321)
-        self.assertTrue(body["subscription_event"]["disabled"])
+        self.assertEqual(mock_requests.last_request.json(), {"disabled": True})
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
 
     @requests_mock.mock()
     def test_enable_new_style(self, mock_requests):
-        """New style: id as a separate kwarg."""
+        """New style: id as a separate kwarg uses path-param endpoint."""
+        enabled = dict(expected_sub_ev)
+        enabled["disabled"] = False
+
         mock_requests.register_uri(
             "PATCH",
-            "https://api.chartmogul.com/v1/subscription_events",
+            "https://api.chartmogul.com/v1/subscription_events/7654321/disabled_state",
             request_headers={"Authorization": "Basic dG9rZW46"},
             status_code=200,
-            json=expected_sub_ev,
+            json=enabled,
         )
 
         config = Config("token")
         sub_ev = SubscriptionEvent.enable(config, id=7654321).get()
 
-        body = mock_requests.last_request.json()
-        self.assertEqual(body["subscription_event"]["id"], 7654321)
-        self.assertFalse(body["subscription_event"]["disabled"])
+        self.assertEqual(mock_requests.last_request.json(), {"disabled": False})
+        self.assertFalse(sub_ev.disabled)
 
     @requests_mock.mock()
     def test_modify_with_params_flat(self, mock_requests):

--- a/test/api/test_subscription_event.py
+++ b/test/api/test_subscription_event.py
@@ -225,6 +225,326 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertTrue(isinstance(subscription_events.subscription_events[0], SubscriptionEvent))
 
     @requests_mock.mock()
+    def test_destroy_with_params_flat(self, mock_requests):
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = SubscriptionEvent.destroy_with_params(config, data={"id": 7654321}).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321}},
+        )
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
+    def test_modify_with_params_new_style(self, mock_requests):
+        """New style: id as a separate kwarg, data for properties."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.modify_with_params(
+            config, id=7654321, data={"amount_in_cents": 10}
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321, "amount_in_cents": 10}},
+        )
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_destroy_with_params_new_style(self, mock_requests):
+        """New style: id as a separate kwarg."""
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = SubscriptionEvent.destroy_with_params(
+            config, id=7654321
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321}},
+        )
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
+    def test_disable_new_style(self, mock_requests):
+        """New style: id as a separate kwarg."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.disable(config, id=7654321).get()
+
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertTrue(body["subscription_event"]["disabled"])
+
+    @requests_mock.mock()
+    def test_enable_new_style(self, mock_requests):
+        """New style: id as a separate kwarg."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.enable(config, id=7654321).get()
+
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertFalse(body["subscription_event"]["disabled"])
+
+    @requests_mock.mock()
+    def test_modify_with_params_flat(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.modify_with_params(
+            config, data={"id": 7654321, "amount_in_cents": 10}
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321, "amount_in_cents": 10}},
+        )
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+        self.assertEqual(sub_ev.id, 7654321)
+
+    @requests_mock.mock()
+    def test_disable_subscription_event(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.disable(config, data={"id": 7654321}).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertTrue(body["subscription_event"]["disabled"])
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_enable_subscription_event(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.enable(config, data={"id": 7654321}).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertFalse(body["subscription_event"]["disabled"])
+
+    @requests_mock.mock()
+    def test_destroy_with_params_flat_external_id(self, mock_requests):
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = SubscriptionEvent.destroy_with_params(
+            config,
+            data={
+                "external_id": "evnt_026",
+                "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+            }
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {
+                "subscription_event": {
+                    "external_id": "evnt_026",
+                    "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+                }
+            },
+        )
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
+    def test_modify_with_params_flat_external_id(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.modify_with_params(
+            config,
+            data={
+                "external_id": "evnt_026",
+                "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+                "amount_in_cents": 10,
+            }
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1, "expected call")
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {
+                "subscription_event": {
+                    "external_id": "evnt_026",
+                    "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+                    "amount_in_cents": 10,
+                }
+            },
+        )
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_destroy_with_params_envelope_passthrough(self, mock_requests):
+        """If caller already wraps in subscription_event, don't double-wrap."""
+        mock_requests.register_uri(
+            "DELETE",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=204,
+        )
+
+        config = Config("token")
+        result = SubscriptionEvent.destroy_with_params(
+            config,
+            data={"subscription_event": {"id": 7654321}}
+        ).get()
+
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321}},
+        )
+        self.assertTrue(result is None)
+
+    @requests_mock.mock()
+    def test_modify_with_params_envelope_passthrough(self, mock_requests):
+        """If caller already wraps in subscription_event, don't double-wrap."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.modify_with_params(
+            config,
+            data={"subscription_event": {"id": 7654321, "amount_in_cents": 10}}
+        ).get()
+
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"subscription_event": {"id": 7654321, "amount_in_cents": 10}},
+        )
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_disable_with_external_id_and_ds_uuid(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.disable(
+            config,
+            data={
+                "external_id": "evnt_026",
+                "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+            }
+        ).get()
+
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["external_id"], "evnt_026")
+        self.assertEqual(
+            body["subscription_event"]["data_source_uuid"],
+            "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+        )
+        self.assertTrue(body["subscription_event"]["disabled"])
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_enable_with_external_id_and_ds_uuid(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        sub_ev = SubscriptionEvent.enable(
+            config,
+            data={
+                "external_id": "evnt_026",
+                "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+            }
+        ).get()
+
+        body = mock_requests.last_request.json()
+        self.assertEqual(body["subscription_event"]["external_id"], "evnt_026")
+        self.assertFalse(body["subscription_event"]["disabled"])
+        self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
+
+    @requests_mock.mock()
     def test_all_subscription_events_with_filters(self, mock_requests):
         mock_requests.register_uri(
             "GET",
@@ -265,3 +585,65 @@ class SubscriptionEventTestCase(unittest.TestCase):
             sorted(expected.subscription_events[0].external_id),
         )
         self.assertTrue(isinstance(subscription_events.subscription_events[0], SubscriptionEvent))
+
+    @requests_mock.mock()
+    def test_disable_passthrough_envelope_sets_flag_inside(self, mock_requests):
+        """When caller passes pre-wrapped envelope, disabled flag must go inside it."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        caller_data = {"subscription_event": {"id": 7654321}}
+        config = Config("token")
+        SubscriptionEvent.disable(config, data=caller_data).get()
+
+        body = mock_requests.last_request.json()
+        # disabled must be inside the envelope, not at top level
+        self.assertNotIn("disabled", body)
+        self.assertTrue(body["subscription_event"]["disabled"])
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        # caller's dict must not be mutated
+        self.assertNotIn("disabled", caller_data["subscription_event"])
+
+    @requests_mock.mock()
+    def test_enable_passthrough_envelope_sets_flag_inside(self, mock_requests):
+        """When caller passes pre-wrapped envelope, disabled=False must go inside it."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        caller_data = {"subscription_event": {"id": 7654321}}
+        config = Config("token")
+        SubscriptionEvent.enable(config, data=caller_data).get()
+
+        body = mock_requests.last_request.json()
+        self.assertNotIn("disabled", body)
+        self.assertFalse(body["subscription_event"]["disabled"])
+        self.assertEqual(body["subscription_event"]["id"], 7654321)
+        self.assertNotIn("disabled", caller_data["subscription_event"])
+
+    @requests_mock.mock()
+    def test_disable_does_not_mutate_caller_dict(self, mock_requests):
+        """Flat-param disable must not mutate the caller's dict in-place."""
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        caller_data = {"id": 7654321}
+        config = Config("token")
+        SubscriptionEvent.disable(config, data=caller_data).get()
+
+        # caller's original dict should not have been modified
+        self.assertNotIn("disabled", caller_data)

--- a/test/api/test_subscription_event.py
+++ b/test/api/test_subscription_event.py
@@ -22,6 +22,9 @@ expected_sub_ev = {
     "currency": "USD",
     "amount_in_cents": 1000,
     "event_order": 123,
+    "disabled": True,
+    "disabled_at": "2026-04-10 10:00:00.000",
+    "disabled_by": "wiktor@chartmogul.com",
 }
 
 sub_ev_list_expected = {
@@ -39,6 +42,9 @@ sub_ev_list_expected = {
             "currency": "USD",
             "amount_in_cents": 1000,
             "event_order": 123,
+            "disabled": True,
+            "disabled_at": "2026-04-10 10:00:00.000",
+            "disabled_by": "wiktor@chartmogul.com",
         }
     ],
     "cursor": "cursor==",
@@ -91,6 +97,9 @@ class SubscriptionEventTestCase(unittest.TestCase):
         self.assertTrue(isinstance(sub_ev, SubscriptionEvent))
         self.assertEqual(sub_ev.id, expected.id)
         self.assertEqual(sub_ev.external_id, expected.external_id)
+        self.assertTrue(sub_ev.disabled)
+        self.assertEqual(sub_ev.disabled_by, "wiktor@chartmogul.com")
+        self.assertIsNotNone(sub_ev.disabled_at)
 
     @requests_mock.mock()
     def test_delete_subscription_event_with_id(self, mock_requests):

--- a/test/api/test_subscription_event_disable.py
+++ b/test/api/test_subscription_event_disable.py
@@ -1,0 +1,67 @@
+import unittest
+
+import requests_mock
+
+from chartmogul import SubscriptionEvent, Config
+
+
+expected_sub_ev = {
+    "id": 7654321,
+    "external_id": "evnt_026",
+    "customer_external_id": "scus_022",
+    "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+    "event_type": "subscription_start_scheduled",
+    "event_date": "2022-03-30 23:00:00.000",
+    "effective_date": "2022-04-01 23:00:00.000",
+    "subscription_external_id": "sub_0001",
+    "plan_external_id": "gold_monthly",
+    "currency": "USD",
+    "amount_in_cents": 1000,
+    "disabled": True,
+}
+
+
+class SubscriptionEventDisableByIdTestCase(unittest.TestCase):
+
+    @requests_mock.mock()
+    def test_disable_by_id(self, mock_requests):
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events/7654321/disabled_state",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=expected_sub_ev,
+        )
+
+        config = Config("token")
+        result = SubscriptionEvent.disable_by_id(
+            config, id=7654321, data={"disabled": True}
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertEqual(
+            mock_requests.last_request.json(), {"disabled": True}
+        )
+        self.assertTrue(isinstance(result, SubscriptionEvent))
+        self.assertTrue(result.disabled)
+
+    @requests_mock.mock()
+    def test_enable_by_id(self, mock_requests):
+        enabled = dict(expected_sub_ev)
+        enabled["disabled"] = False
+
+        mock_requests.register_uri(
+            "PATCH",
+            "https://api.chartmogul.com/v1/subscription_events/7654321/disabled_state",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json=enabled,
+        )
+
+        config = Config("token")
+        result = SubscriptionEvent.disable_by_id(
+            config, id=7654321, data={"disabled": False}
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertFalse(result.disabled)

--- a/test/api/test_subscription_event_disable.py
+++ b/test/api/test_subscription_event_disable.py
@@ -21,10 +21,11 @@ expected_sub_ev = {
 }
 
 
-class SubscriptionEventDisableByIdTestCase(unittest.TestCase):
+class SubscriptionEventDisablePathParamTestCase(unittest.TestCase):
 
     @requests_mock.mock()
-    def test_disable_by_id(self, mock_requests):
+    def test_disable_with_id_kwarg_uses_path_param(self, mock_requests):
+        """disable(config, id=123) uses PATCH /subscription_events/{id}/disabled_state."""
         mock_requests.register_uri(
             "PATCH",
             "https://api.chartmogul.com/v1/subscription_events/7654321/disabled_state",
@@ -34,9 +35,7 @@ class SubscriptionEventDisableByIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = SubscriptionEvent.disable_by_id(
-            config, id=7654321, data={"disabled": True}
-        ).get()
+        result = SubscriptionEvent.disable(config, id=7654321).get()
 
         self.assertEqual(mock_requests.call_count, 1)
         self.assertEqual(
@@ -46,7 +45,8 @@ class SubscriptionEventDisableByIdTestCase(unittest.TestCase):
         self.assertTrue(result.disabled)
 
     @requests_mock.mock()
-    def test_enable_by_id(self, mock_requests):
+    def test_enable_with_id_kwarg_uses_path_param(self, mock_requests):
+        """enable(config, id=123) uses PATCH /subscription_events/{id}/disabled_state."""
         enabled = dict(expected_sub_ev)
         enabled["disabled"] = False
 
@@ -59,9 +59,10 @@ class SubscriptionEventDisableByIdTestCase(unittest.TestCase):
         )
 
         config = Config("token")
-        result = SubscriptionEvent.disable_by_id(
-            config, id=7654321, data={"disabled": False}
-        ).get()
+        result = SubscriptionEvent.enable(config, id=7654321).get()
 
         self.assertEqual(mock_requests.call_count, 1)
+        self.assertEqual(
+            mock_requests.last_request.json(), {"disabled": False}
+        )
         self.assertFalse(result.disabled)


### PR DESCRIPTION
## Summary

- `modify_with_params` / `destroy_with_params` now accept flat params, envelope-wrapped params, and identifier as separate kwarg
- `disable` / `enable` convenience methods — support both id path param and body-based modify
- Added `disabled` field to schema
- `disable_by_id` endpoint: PATCH `/subscription_events/{ID}/disabled_state`

## Backwards compatibility

| Change | Breaking? |
|---|---|
| `modify_with_params`/`destroy_with_params` accept flat params | No — envelope-wrapped calls still work |
| Added `disable`/`enable` classmethods | No — new methods |
| Added `disabled` field to schema | No — additive field |
| `disable(config, id=123)` dispatches to path-param endpoint | No — new calling pattern |

## Testing instructions

Test account: **WiktorOnboarding** (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). Impersonate `wiktor@chartmogul.com` for API key.

```python
# Modify with flat params (new style)
se = chartmogul.SubscriptionEvent.modify_with_params(
    config, id=543978478, data={'amount_in_cents': 2000}
).get()

# Modify with flat params (old style — still works)
se = chartmogul.SubscriptionEvent.modify_with_params(
    config, data={'id': 543978478, 'amount_in_cents': 2000}
).get()

# Disable by id path param
se = chartmogul.SubscriptionEvent.disable(config, id=543978478).get()

# Enable by id path param
se = chartmogul.SubscriptionEvent.enable(config, id=543978478).get()

# Disable by body (still works)
se = chartmogul.SubscriptionEvent.disable(
    config, data={'id': 543978478}
).get()
```

## Test plan

- [x] Added 20 tests: flat params, envelope passthrough, new-style kwargs, disable/enable (path + body), no-mutation
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)