### PR TITLE
Add Tags.add_by_email for bulk tagging by email (PIP-310)

### DIFF
--- a/chartmogul/api/tags.py
+++ b/chartmogul/api/tags.py
@@ -36,3 +36,6 @@ class Tags(Resource):
             return cls._customers(customers)
         else:
             return cls._schema.load(jsonObj)
+
+
+Tags.add_by_email = Tags._method("create", "post", "/customers/attributes/tags")

--- a/test/api/test_tags_by_email.py
+++ b/test/api/test_tags_by_email.py
@@ -1,0 +1,45 @@
+import unittest
+
+import requests_mock
+
+from chartmogul import Tags, Config
+
+
+class TagsByEmailTestCase(unittest.TestCase):
+
+    @requests_mock.mock()
+    def test_add_by_email(self, mock_requests):
+        mock_requests.register_uri(
+            "POST",
+            "https://api.chartmogul.com/v1/customers/attributes/tags",
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            status_code=200,
+            json={
+                "entries": [
+                    {
+                        "id": 1,
+                        "uuid": "cus_test",
+                        "external_id": "ext_1",
+                        "name": "Test Customer",
+                        "email": "test@example.com",
+                        "data_source_uuid": "ds_1",
+                        "status": "Active",
+                        "customer-since": "2025-01-01T00:00:00.000Z",
+                        "attributes": {"tags": ["important"]},
+                    }
+                ]
+            },
+        )
+
+        config = Config("token")
+        result = Tags.add_by_email(
+            config,
+            data={"email": "test@example.com", "tags": ["important"]},
+        ).get()
+
+        self.assertEqual(mock_requests.call_count, 1)
+        self.assertEqual(
+            mock_requests.last_request.json(),
+            {"email": "test@example.com", "tags": ["important"]},
+        )
+        self.assertEqual(len(result.entries), 1)


### PR DESCRIPTION
## Summary

`Tags.add_by_email(config, data={'email': '...', 'tags': [...]})`: POST `/customers/attributes/tags` — adds tags to all customers matching the given email address.

## Backwards compatibility

| Change | Breaking? |
|---|---|
| Added `Tags.add_by_email` method | No — new method |

## Testing instructions

Test account: **WiktorOnboarding** (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). Impersonate `wiktor@chartmogul.com` for API key.

```python
result = chartmogul.Tags.add_by_email(
    config,
    data={'email': 'test@example.com', 'tags': ['important']}
).get()
# Returns list of customers that were tagged
print(f"Tagged {len(result.entries)} customer(s)")
```

## Test plan

- [x] Added 1 test verifying request body and response deserialization
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)