### PR TITLE
Add remaining Account include params (PIP-76)

### DIFF
--- a/chartmogul/api/account.py
+++ b/chartmogul/api/account.py
@@ -17,6 +17,9 @@ class Account(Resource):
         week_start_on = fields.String()
         churn_recognition = fields.String(allow_none=True)
         churn_when_zero_mrr = fields.Raw(allow_none=True)
+        auto_churn_subscription = fields.Raw(allow_none=True)
+        refund_handling = fields.String(allow_none=True)
+        proximate_movement_reclassification = fields.String(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):

--- a/test/api/test_account.py
+++ b/test/api/test_account.py
@@ -85,8 +85,8 @@ jsonResponseWithInclude = {
     "currency": "EUR",
     "time_zone": "Europe/Berlin",
     "week_start_on": "sunday",
-    "churn_recognition": "immediate",
-    "churn_when_zero_mrr": "ignore",
+    "churn_recognition": "churn_at_time_of_cancelation",
+    "churn_when_zero_mrr": False,
 }
 
 
@@ -108,8 +108,8 @@ class AccountIncludeTestCase(unittest.TestCase):
             config, include="churn_recognition,churn_when_zero_mrr"
         ).get()
         self.assertTrue(isinstance(account, Account))
-        self.assertEqual(account.churn_recognition, "immediate")
-        self.assertEqual(account.churn_when_zero_mrr, "ignore")
+        self.assertEqual(account.churn_recognition, "churn_at_time_of_cancelation")
+        self.assertEqual(account.churn_when_zero_mrr, False)
         self.assertEqual(
             mock_requests.last_request.qs,
             {"include": ["churn_recognition,churn_when_zero_mrr"]},
@@ -122,7 +122,7 @@ class AccountIncludeTestCase(unittest.TestCase):
             "currency": "EUR",
             "time_zone": "Europe/Berlin",
             "week_start_on": "sunday",
-            "churn_recognition": "immediate",
+            "churn_recognition": "churn_at_time_of_cancelation",
         }
 
         mock_requests.register_uri(
@@ -137,7 +137,7 @@ class AccountIncludeTestCase(unittest.TestCase):
         config = Config("token")
         account = Account.retrieve(config, include="churn_recognition").get()
         self.assertTrue(isinstance(account, Account))
-        self.assertEqual(account.churn_recognition, "immediate")
+        self.assertEqual(account.churn_recognition, "churn_at_time_of_cancelation")
         self.assertFalse(hasattr(account, "churn_when_zero_mrr"))
 
     @requests_mock.mock()

--- a/test/api/test_account.py
+++ b/test/api/test_account.py
@@ -139,3 +139,45 @@ class AccountIncludeTestCase(unittest.TestCase):
         self.assertTrue(isinstance(account, Account))
         self.assertEqual(account.churn_recognition, "immediate")
         self.assertFalse(hasattr(account, "churn_when_zero_mrr"))
+
+    @requests_mock.mock()
+    def test_retrieve_with_all_include_params(self, mock_requests):
+        allIncludeResponse = {
+            "id": "acct_a1b2c3d4",
+            "name": "Example Test Company",
+            "currency": "EUR",
+            "time_zone": "Europe/Berlin",
+            "week_start_on": "sunday",
+            "churn_recognition": "churn_at_time_of_cancelation",
+            "churn_when_zero_mrr": False,
+            "auto_churn_subscription": False,
+            "refund_handling": "refund_ignore",
+            "proximate_movement_reclassification": "one_hour_reclassification",
+        }
+
+        include = (
+            "churn_recognition,churn_when_zero_mrr,"
+            "auto_churn_subscription,refund_handling,"
+            "proximate_movement_reclassification"
+        )
+
+        mock_requests.register_uri(
+            "GET",
+            "https://api.chartmogul.com/v1/account?include=" + include,
+            request_headers={"Authorization": "Basic dG9rZW46"},
+            headers={"Content-Type": "application/json"},
+            status_code=200,
+            json=allIncludeResponse,
+        )
+
+        config = Config("token")
+        account = Account.retrieve(config, include=include).get()
+        self.assertTrue(isinstance(account, Account))
+        self.assertEqual(account.churn_recognition, "churn_at_time_of_cancelation")
+        self.assertEqual(account.churn_when_zero_mrr, False)
+        self.assertEqual(account.auto_churn_subscription, False)
+        self.assertEqual(account.refund_handling, "refund_ignore")
+        self.assertEqual(
+            account.proximate_movement_reclassification,
+            "one_hour_reclassification"
+        )


### PR DESCRIPTION
## Summary

Follow-up to #132. Adds the missing `include` query param fields:
- `auto_churn_subscription` (boolean)
- `refund_handling` (string)
- `proximate_movement_reclassification` (string)

Full include set now supported:
```
include=churn_recognition,churn_when_zero_mrr,auto_churn_subscription,refund_handling,proximate_movement_reclassification
```

## Backwards compatibility

| Change | Breaking? |
|---|---|
| Added 3 new `allow_none=True` fields to Account schema | No — absent when `include` not used |

## Testing instructions

Test account: **WiktorOnboarding** (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). Impersonate `wiktor@chartmogul.com` for API key.

```python
account = chartmogul.Account.retrieve(
    config,
    include='churn_recognition,churn_when_zero_mrr,auto_churn_subscription,refund_handling,proximate_movement_reclassification'
).get()
print(account.auto_churn_subscription)               # False
print(account.refund_handling)                        # "refund_ignore"
print(account.proximate_movement_reclassification)    # "one_hour_reclassification"
```

## Test plan

- [x] Added 1 test covering all 5 include params together
- [x] All 6 account tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)